### PR TITLE
Fix Selenium compatibility for current Chrome and BOSS直聘

### DIFF
--- a/website_oper/finding_jobs.py
+++ b/website_oper/finding_jobs.py
@@ -1,4 +1,11 @@
+import os
 import time
+
+# 让 Selenium 连接 ChromeDriver 时绕过系统代理
+os.environ['NO_PROXY'] = 'localhost,127.0.0.1'
+
+import chromedriver_autoinstaller
+chromedriver_autoinstaller.install()
 
 from selenium import webdriver
 from selenium.common import NoSuchElementException
@@ -20,10 +27,18 @@ def open_browser_with_options(url, browser):
     global driver
     options = Options()
     options.add_experimental_option("detach", True)
+    # 反自动化检测
+    options.add_experimental_option("excludeSwitches", ["enable-automation"])
+    options.add_experimental_option("useAutomationExtension", False)
+    options.add_argument("--disable-blink-features=AutomationControlled")
 
     if browser == "chrome":
         driver = webdriver.Chrome(options=options)
         driver.maximize_window()
+        # 隐藏 webdriver 标志
+        driver.execute_cdp_cmd("Page.addScriptToEvaluateOnNewDocument", {
+            "source": "Object.defineProperty(navigator, 'webdriver', {get: () => undefined})"
+        })
     elif browser == "edge":
         driver = webdriver.Edge()
         driver.maximize_window()
@@ -34,39 +49,56 @@ def open_browser_with_options(url, browser):
         raise ValueError("Browser type not supported")
 
     driver.get(url)
+    print(f"页面加载中... 当前URL: {driver.current_url}")
 
-    # 等待直到页面包含特定的 XPath 元素
-    xpath_locator = "//*[@id='header']/div[1]/div[3]/div/a"
-    WebDriverWait(driver, 10).until(
-        EC.presence_of_element_located((By.XPATH, xpath_locator))
-    )
+    # 等待页面加载完成
+    try:
+        WebDriverWait(driver, 30).until(
+            lambda d: d.title and len(d.title) > 0
+        )
+        print(f"页面已加载，标题: {driver.title}")
+    except Exception:
+        print(f"等待页面超时，当前URL: {driver.current_url}")
+        raise
 
 
 def log_in():
     global driver
 
-    # 点击按钮
-    login_button = driver.find_element(By.XPATH, "//*[@id='header']/div[1]/div[3]/div/a")
+    # 用文字内容找到"登录/注册"按钮
+    try:
+        login_button = WebDriverWait(driver, 15).until(
+            EC.element_to_be_clickable((By.LINK_TEXT, "登录/注册"))
+        )
+    except Exception:
+        # 备选：部分匹配
+        login_button = WebDriverWait(driver, 10).until(
+            EC.element_to_be_clickable((By.PARTIAL_LINK_TEXT, "登录"))
+        )
     login_button.click()
+    print("已点击登录按钮，等待登录方式选择...")
+    time.sleep(2)
 
-    # 等待微信登录按钮出现
-    xpath_locator_wechat_login = "//*[@id='wrap']/div/div[2]/div[2]/div[2]/div[1]/div[4]/a"
-    WebDriverWait(driver, 10).until(
-        EC.presence_of_element_located((By.XPATH, xpath_locator_wechat_login))
-    )
+    # 找到微信登录按钮（用文字匹配）
+    try:
+        wechat_button = WebDriverWait(driver, 10).until(
+            EC.element_to_be_clickable((By.PARTIAL_LINK_TEXT, "微信"))
+        )
+        wechat_button.click()
+        print("已选择微信登录，请扫码...")
+    except Exception:
+        print("未找到微信登录按钮，请手动选择登录方式...")
 
-    wechat_button = driver.find_element(By.XPATH, "//*[@id='wrap']/div/div[2]/div[2]/div[2]/div[1]/div[4]/a")
-    wechat_button.click()
-
-    xpath_locator_wechat_logo = "//*[@id='wrap']/div/div[2]/div[2]/div[1]/div[2]/div[1]/img"
-    WebDriverWait(driver, 10).until(
-        EC.presence_of_element_located((By.XPATH, xpath_locator_wechat_logo))
-    )
-
-    xpath_locator_login_success = "//*[@id='header']/div[1]/div[3]/ul/li[2]/a"
-    WebDriverWait(driver, 60).until(
-        EC.presence_of_element_located((By.XPATH, xpath_locator_login_success))
-    )
+    # 等待用户扫码登录成功（最多等 120 秒）
+    print("等待扫码登录... (最多等待120秒)")
+    try:
+        WebDriverWait(driver, 120).until(
+            lambda d: "登录" not in d.page_source[:5000] or
+                      d.find_elements(By.CSS_SELECTOR, '.user-nav, .nav-userinfo, [ka="header-username"]')
+        )
+        print("登录成功！")
+    except Exception:
+        print("登录超时，请确认是否已扫码登录")
 
 
 def get_job_description():


### PR DESCRIPTION
## Summary
- Add `chromedriver-autoinstaller` for automatic ChromeDriver version management
- Bypass system SOCKS proxy for Selenium-to-ChromeDriver local connections (`NO_PROXY`)
- Add anti-automation-detection options to prevent BOSS直聘 from blocking Selenium
- Replace hardcoded XPath locators with text-based element matching for login flow (adapts to site redesign)
- Increase WeChat QR scan wait timeout to 120 seconds

## Detailed Changes

### 1. 绕过系统代理
```python
os.environ['NO_PROXY'] = 'localhost,127.0.0.1'
```
**为什么**：如果系统跑着 SOCKS 代理（如 Clash/V2Ray），Selenium 连接本地 ChromeDriver 的 HTTP 请求会被代理拦截，返回 502。设置 `NO_PROXY` 让本地连接绕过代理，浏览器访问 BOSS 直聘仍然正常走代理。

### 2. 自动安装 ChromeDriver
```python
import chromedriver_autoinstaller
chromedriver_autoinstaller.install()
```
**为什么**：原项目没有处理 ChromeDriver 安装，如果系统上没有 chromedriver，Selenium 启动直接报 `WebDriverException`。这个库会自动检测 Chrome 版本并下载匹配的 ChromeDriver。

### 3. 反自动化检测
```python
options.add_experimental_option("excludeSwitches", ["enable-automation"])
options.add_experimental_option("useAutomationExtension", False)
options.add_argument("--disable-blink-features=AutomationControlled")
driver.execute_cdp_cmd("Page.addScriptToEvaluateOnNewDocument", {
    "source": "Object.defineProperty(navigator, 'webdriver', {get: () => undefined})"
})
```
**为什么**：BOSS 直聘检测到 Selenium 自动化浏览器后会拦截页面（页面加载后变空白）。这四行分别：
- 隐藏 Chrome 顶部的"Chrome 正受到自动测试软件的控制"提示栏
- 禁用自动化扩展
- 禁用 `AutomationControlled` 特征标志
- 把 `navigator.webdriver` 从 `true` 改为 `undefined`，让网站 JS 检测不到

### 4. 页面等待方式改为通用逻辑
```python
# 旧：等待特定 XPath 的登录按钮
xpath_locator = "//*[@id='header']/div[1]/div[3]/div/a"
WebDriverWait(driver, 10).until(...)

# 新：等待页面标题加载
WebDriverWait(driver, 30).until(lambda d: d.title and len(d.title) > 0)
```
**为什么**：BOSS 直聘改版后原来的 XPath 已经不存在了，导致 10 秒超时报错。改为检查页面标题是否加载完成，不依赖具体 DOM 结构，更稳定。超时也从 10 秒增加到 30 秒，给慢网络留余量。

### 5. 登录流程：XPath 全部替换为文字定位
```python
# 旧：6 个硬编码 XPath
"//*[@id='header']/div[1]/div[3]/div/a"
"//*[@id='wrap']/div/div[2]/div[2]/div[2]/div[1]/div[4]/a"
"//*[@id='wrap']/div/div[2]/div[2]/div[1]/div[2]/div[1]/img"
"//*[@id='header']/div[1]/div[3]/ul/li[2]/a"

# 新：用按钮文字匹配
By.LINK_TEXT, "登录/注册"
By.PARTIAL_LINK_TEXT, "微信"
```
**为什么**：
- 那些 XPath 类似 `/div[1]/div[3]/div/a` 是绝对路径，网站只要改一层 DOM 嵌套就全部失效，BOSS 直聘已经改版导致这些 XPath 全部超时
- 用文字定位（"登录/注册"、"微信"）不依赖 DOM 结构，只要按钮文字不变就能工作，健壮得多
- 登录成功检测从等待特定 XPath 改为检查页面中是否还有"登录"字样 + 是否出现用户导航元素
- 扫码超时从 60 秒增加到 120 秒，实际扫码经常需要更多时间
- 加了 `try/except` 和 `print` 提示，出错时能看到是哪一步失败

## Known Issue
- BOSS直聘的反爬检测可能仍会将 Selenium 浏览器重定向到空白页（`data:,`），可能需要使用 `undetected-chromedriver` 进一步解决

## Test plan
- [ ] Run `python main.py` and verify Chrome opens BOSS直聘 successfully
- [ ] Verify login button is found and clicked automatically
- [ ] Verify WeChat QR code login flow works with 120s timeout
- [ ] Test on systems with and without SOCKS proxy configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)