### PR TITLE
Make the project usable for someone who isn't me

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,52 @@
+# 把本文件复制成 .env，按需填写下面的 key。脚本会自动检测你配了哪些 provider，
+# 只配一个 → 直接用那个；配多个 → 启动时让你选；一个都不配 → 启动就告诉你去哪填。
+#
+# Copy this file to .env and fill in whatever API keys you have. The script
+# auto-detects which providers are configured: one key → use it directly,
+# multiple → ask at startup, none → tell you to come back here.
+
+# ─── LLM providers (至少配一个 / pick at least one) ──────────────────────────
+
+# DeepSeek（最便宜，推荐先用这个）— https://platform.deepseek.com/api_keys
+DEEPSEEK_API_KEY=
+
+# OpenAI（如果用 Assistants 模式必须配这个）— https://platform.openai.com/api-keys
+OPENAI_API_KEY=
+# 可选：自建 / 代理 OpenAI 网关时改 base_url
+# OPENAI_BASE_URL=https://your-proxy.example.com/v1
+
+# Anthropic Claude — https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=
+
+# ─── 求职信息（可选，不填会在启动时让你输入）/ Job details (optional) ───────
+
+# 你在打招呼语结尾使用的署名
+# Your name as it appears at the bottom of the cover letter
+BOSS_USR_NAME=
+
+# 要选的岗位 tag，比如 "后端开发（成都）"。留空 → 用 BOSS 的默认推荐 feed
+# The job category tag, e.g. "Backend Engineer (Shanghai)". Empty = default recommended feed
+BOSS_LABEL=
+
+# 简历 PDF 路径，留空 → 默认 ./resume/my_cover.pdf
+# Resume PDF path. Empty = default ./resume/my_cover.pdf
+RESUME_PATH=
+
+# ─── 行为开关 / Behavior toggles ─────────────────────────────────────────────
+
+# DRY_RUN=1 时只生成、不发送，方便调 prompt
+# DRY_RUN=1 generates and logs letters without clicking "立即沟通"
+# DRY_RUN=1
+
+# 单独存放 Chrome profile 的目录。第一次扫码登录后 cookie 会留在这里，
+# 之后跑都跳过扫码。默认 ./chrome_profile
+# Directory holding the dedicated Chrome profile. Persisted login cookies live
+# here; subsequent runs skip the QR scan. Default ./chrome_profile
+# BOSS_CHROME_PROFILE=
+
+# 打招呼语长度边界（兜底防止 LLM 抽风）。默认 30 / 800
+# LETTER_MIN_LEN=30
+# LETTER_MAX_LEN=800
+
+# JSONL 审计日志路径，默认 ./logs/letters.jsonl
+# LETTER_LOG_PATH=./logs/letters.jsonl

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,5 @@
 /vectorstores/
 /logs/
 /chrome_profile/
+/assistant.json
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,161 @@
-## Main Content
-This is a completely free script — all you need to do is configure your own OpenAI API.
+# BOSS Zhipin Auto-Greet
 
-If you find this script helpful during this tough job-hunting season, I would be truly honored if you could give it a **star** ⭐️.
+[中文文档](README_CN.md) · [English](README.md)
 
-If this script brings you some warmth in this cold recruitment season, that alone would mean a lot to me.
+Reads job descriptions from BOSS Zhipin, asks an LLM to write a polite cover-letter greeting, validates it, then sends it to the recruiter. DeepSeek / OpenAI / Claude all supported — any single key gets you running.
 
-Please don’t use this script to exploit others. If someone is already at the point of relying on scripts to apply for jobs, they probably don’t have much left to be squeezed.
+> The original author paused maintenance; a small group of us keeps it going. We've migrated to [uv](https://docs.astral.sh/uv/), dropped the langchain stack, and replaced Selenium with [nodriver](https://github.com/ultrafunkamsterdam/nodriver) (much steadier against BOSS's anti-bot).
 
+> ⚠️ Please don't weaponise this against vulnerable jobseekers. If someone needs a script to apply for jobs, there's not much left to squeeze out of them.
 
+---
 
-[中文文档](README_CN.md) 
+## Quick Start (5 minutes)
 
-[English](README.md)
+### Prerequisites
 
-Thanks to all the amazing people supporting my work!
+- Python >= 3.11
+- macOS / Linux / Windows. Chrome / Chromium only — nodriver does not support Edge or Safari.
+- A stable Chrome installation (not Chromium beta).
+- [uv](https://docs.astral.sh/uv/): `curl -LsSf https://astral.sh/uv/install.sh | sh`
+
+### Run it
+
+```bash
+# 1. Clone + install deps
+git clone https://github.com/longsizhuo/BossZhiPin_Job_Search.git
+cd BossZhiPin_Job_Search
+uv sync
+
+# 2. Configure API keys
+cp .env.example .env
+# Edit .env, fill in at least one LLM provider key (see field reference below)
+
+# 3. Drop in your resume
+mkdir -p resume
+# Copy your PDF resume in and name it my_cover.pdf
+# Or set RESUME_PATH in .env to point elsewhere
+
+# 4. Try it dry-run first (generates without sending)
+DRY_RUN=1 uv run main.py
+
+# 5. Once you're happy with logs/letters.jsonl, drop DRY_RUN to actually send
+uv run main.py
+```
+
+### First run: scan to log in
+
+The script starts Chrome with a dedicated profile at `./chrome_profile/` (**your daily Chrome is untouched**). The first run gets redirected to BOSS's login page, clicks "WeChat scan login" for you, and waits up to 5 minutes for you to scan the QR. Once you're logged in the cookie lives in `chrome_profile/` and **every subsequent run skips the login step**.
+
+---
+
+## `.env` field reference
+
+The repo ships a fully-commented template at [`.env.example`](.env.example). Highlights:
+
+| Field | Purpose | Required |
+|---|---|---|
+| `DEEPSEEK_API_KEY` | DeepSeek key ([signup](https://platform.deepseek.com/api_keys)) | pick one |
+| `OPENAI_API_KEY` | OpenAI key, used by the Assistants flow ([signup](https://platform.openai.com/api-keys)) | pick one |
+| `ANTHROPIC_API_KEY` | Anthropic Claude key ([signup](https://console.anthropic.com/settings/keys)) | pick one |
+| `BOSS_USR_NAME` | Your name; signed at the bottom of every letter | no — prompted at startup if unset |
+| `BOSS_LABEL` | Job category tag, e.g. `"Backend Engineer (Shanghai)"` | no — empty = BOSS's default recommended feed |
+| `RESUME_PATH` | Path to your PDF resume | no — defaults to `./resume/my_cover.pdf` |
+| `DRY_RUN` | `1` = generate & log but don't send | no |
+| `BOSS_CHROME_PROFILE` | Custom Chrome profile dir | no — defaults to `./chrome_profile` |
+| `LETTER_MIN_LEN` / `LETTER_MAX_LEN` | Letter length bounds | no — default 30 / 800 |
+| `LETTER_LOG_PATH` | Audit log path | no — default `./logs/letters.jsonl` |
+
+**With exactly one provider key in `.env`, the script auto-selects it — no menu.** Multiple keys, you pick at startup. Zero keys, you get a list of signup URLs and an exit.
+
+---
+
+## Picking a provider
+
+| Provider | How letters are generated | Pro | Con |
+|---|---|---|---|
+| DeepSeek | RAG with local Chroma + sentence-transformers retrieval over your resume | Cheapest, quality is fine | Downloads a ~430MB embedding model on first run |
+| OpenAI | Assistants API + OpenAI-hosted Vector Stores | No local embedding model needed | Calls cost more than DeepSeek |
+| Claude | RAG (same as DeepSeek path) | Best-sounding tone | Model is expensive, but RAG keeps tokens low |
+
+---
+
+## Safety: dry-run + audit log
+
+Every generated letter is run through `validate_letter` in [`audit.py`](audit.py) before sending:
+- Length bounds (default 30–800 chars)
+- Must contain at least one CJK character
+- Blacklist substrings (`Error`, `Traceback`, `As an AI`, `` ``` ``, …) — any hit blocks the send
+
+Sent, blocked, dry-run — every attempt appends a JSONL record to `./logs/letters.jsonl` with the JD, the letter, provider, model and validation status. Use this for incident review and prompt iteration:
+
+```bash
+tail -f logs/letters.jsonl | jq '{ts, sent, validation_ok, validation_reasons, letter_len}'
+```
+
+---
+
+## Troubleshooting
+
+### Browser crashes on launch / `SessionNotCreatedException`
+Older versions used `undetected-chromedriver`, which bundles a chromedriver binary that has to match Chrome's version exactly. This repo no longer uses it — [nodriver](https://github.com/ultrafunkamsterdam/nodriver) talks CDP directly, so this whole error class is structurally impossible. If Chrome still crashes, it's almost certainly a profile lock.
+
+### Chrome opens but looks empty / "this isn't my Chrome"
+By design — the script uses a dedicated profile at `./chrome_profile/`, separate from your daily browser. This avoids leaking your extensions / sessions into automation. First run prompts a QR scan; subsequent runs reuse the cookie.
+
+If you really want to use your daily Chrome profile, **fully quit Chrome first** (menu bar → Quit Google Chrome) and:
+```bash
+BOSS_CHROME_PROFILE="$HOME/Library/Application Support/Google/Chrome" uv run main.py
+```
+
+### A blank new-tab page shows up instead of BOSS
+Used to happen when the persistent profile restored other tabs. Fixed in [commit `7dbdf37`](https://github.com/longsizhuo/BossZhiPin_Job_Search/commit/7dbdf37): the controlled page now opens in its own dedicated window.
+
+### Script hangs after "页面已稳定"
+Used to be a `tab.select(timeout=0)` block. Fixed. If you still see it, paste console output into an issue.
+
+### "❌ Resume file not found"
+Drop your PDF at `./resume/my_cover.pdf`, or set `RESUME_PATH` in `.env`.
+
+### "❌ No API key found"
+Pick one of the three providers, sign up, paste the key into `.env`. Any one will work.
+
+---
+
+## Project layout
+
+```
+.
+├── main.py                       # Entry point: env validation, provider routing
+├── models/
+│   ├── llm.py                    # Provider config + chat-completions call for DeepSeek/Claude
+│   ├── openai_assistant.py       # OpenAI Assistants flow (with Vector Store)
+│   └── prompts.py                # Cover-letter prompt template
+├── website_oper/
+│   ├── finding_jobs.py           # Browser automation (nodriver), sync facade over async impls
+│   └── write_response.py         # Per-job loop: JD → generate → validate → send/log
+├── vectorization.py              # PDF parse + sentence-transformers embed + Chroma persistence
+├── audit.py                      # Letter validation + JSONL audit log
+└── .env.example                  # Fully-commented environment template
+```
+
+---
+
+## Help wanted
+
+We're looking for contributors interested in:
+- Electron front-end UI
+- Resume-attachment support on the BOSS chat
+- Application history / auto follow-up
+- Multi-account support
+
+Issues and PRs welcome.
+
+---
+
+## Thanks
+
+Thanks to everyone who's supported this project:
 
 <p align="left">
     <a href="https://github.com/longsizhuo/BossZhiPin_Job_Search/graphs/contributors">
@@ -21,132 +163,7 @@ Thanks to all the amazing people supporting my work!
     </a>
 </p>
 
+### Forks worth a look
 
-
-## Steps to Use
-
-1. First, configure your OpenAI API (using a `.env` file or set it directly in the code).
-2. Upload your PDF resume to the `auto_job_find` folder and name it **"my_cover.pdf"**.
-3. Install all required packages.
-4. Run `write_response.py`.
-
----
-
-## About the Assistant
-
-The script will automatically create an OpenAI Assistant and generate a local `.json` file. This file is only created on the first run. On subsequent runs, the existing Assistant will be reused if the JSON file is detected.
-
----
-
-## Required Packages
-
-Dependencies are declared in `pyproject.toml` and locked in `uv.lock`. The full
-runtime set is: `openai`, `python-dotenv`, `selenium`, `pypdf`, `chromadb`,
-`sentence-transformers`, `packaging`.
-
----
-
-## About RPA
-
-Tutorial video on how to get started with [RPA](https://www.youtube.com/watch?v=65OPFmEgCbM&list=PLx4LEkEdFArgrdD_lvXe_hYBy8zM0Sp3b&index=1)
-
-Recommended Plugin: Intellibot@Selenium Library
-
----
-
-### 📺 Simple Tutorial Videos
-
-- [Bilibili](https://www.bilibili.com/video/BV1UC4y1N78v/?share_source=copy_web&vd_source=b2608434484091fcc64d4eb85233122d)
-- [YouTube](https://youtu.be/TlnytEi2lD8?si=jfcDj2MZqBptziZc)
-
----
-
-## How to Run
-
-The project uses [uv](https://docs.astral.sh/uv/) for dependency management.
-Install uv (`curl -LsSf https://astral.sh/uv/install.sh | sh`), clone the repo,
-then run from the project root:
-
-```bash
-uv sync          # create .venv and install all dependencies
-uv run main.py   # launch the CLI
-```
-
-### Run with Assistant Mode (OpenAI Assistants API)
-
-1. Open the `.env` file and configure `OPENAI_API_KEY`.
-2. Upload your resume PDF to the `resume` folder, named `my_cover.pdf`.
-3. `uv run main.py` and pick option `2`.
-
-Note: This mode does not support custom APIs but runs faster.
-
-### Run with DeepSeek / Claude (RAG over your resume)
-
-1. Configure `DEEPSEEK_API_KEY` (or `ANTHROPIC_API_KEY` for Claude) in `.env`.
-2. Put your resume PDF in the `resume` folder as `my_cover.pdf`.
-3. `uv run main.py` and pick option `1` (DeepSeek) or `3` (Claude).
-
-Both providers are reached through the OpenAI-compatible endpoint, so no extra
-SDK is required beyond `openai`.
-
-### Safety: dry-run and audit log
-
-Before sending anything to BOSS, every generated letter is validated against
-length bounds and a blacklist of error-string / refusal phrases. Failures are
-logged but never sent.
-
-Every attempt — sent, blocked, or dry-run — is appended to
-`./logs/letters.jsonl` with the job description, the letter, the provider and
-the model. Use this for prompt iteration and incident review:
-
-```bash
-tail -f logs/letters.jsonl | jq '{ts, sent, validation_ok, letter_len}'
-```
-
-To preview generation without sending anything to BOSS, run with `DRY_RUN=1`:
-
-```bash
-DRY_RUN=1 uv run main.py
-```
-
-The Selenium flow still browses and scrapes job descriptions, but skips the
-"立即沟通" click. Tune the prompt by reviewing `logs/letters.jsonl` afterwards.
-
-### Run with ChatGPT-4 and Above
-
-If you're using newer ChatGPT models, you may encounter an error if you're not using version `v1.1.1`:
-
-```
-Error code: 400 - {'error': {'message': "The requested model 'gpt-4o-mini' cannot be used with the Assistants API in v1. Follow the migration guide to upgrade to v2: https://platform.openai.com/docs/assistants/migration."}}
-```
-
-#### Solution:
-1. Upgrade OpenAI package:
-```shell
-pip install --upgrade openai
-```
-2. Modify the `create_assistant` function structure. See the [migration guide](https://platform.openai.com/docs/assistants/migration) for details.
-
-> Alternatively, manually create an assistant on the [OpenAI Platform](https://platform.openai.com/assistants/), then copy its code into your `assistant.json` file:
-```json
-{"assistant_id": "asst_token"}
-```
-
----
-
-## Alternative JavaScript Version
-
-Some kind contributors have built easier-to-use versions based on JavaScript. Although these versions may not support Assistant-based retrieval and may require manual preprocessing of resumes, they are still very helpful.
-
-GitHub link:  
-[https://github.com/noBaldAaa/find-job](https://github.com/noBaldAaa/find-job)
-
----
-
-## Azure-based Version
-
-An alternative version using Azure's OpenAI API is available here:
-[https://github.com/LouisCaixuran/auto_job_find_azure](https://github.com/LouisCaixuran/auto_job_find_azure)
-
-
-
+- [noBaldAaa/find-job](https://github.com/noBaldAaa/find-job) — simpler JS port
+- [LouisCaixuran/auto_job_find_azure](https://github.com/LouisCaixuran/auto_job_find_azure) — Azure OpenAI version

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,153 +1,170 @@
+# BOSS 直聘自动打招呼脚本
 
+[中文文档](README_CN.md) · [English](README.md)
 
-## 正文
-原作者已经暂停更新该项目，现在由我和小伙伴们维护该项目，力及让所有人都可以简单地运行。
+读 BOSS 上的岗位描述，用 LLM 给 HR 生成一封礼貌的打招呼语，按规则审核后再发送。支持 DeepSeek / OpenAI / Claude 三个 provider，任意一个 key 都能起跑。
 
-现在我们已经完成了：
-1. 加入更多的api，如deepseek、Claude（通过 OpenAI 兼容层）
-2. 优化了代码结构，使得代码更加易于理解
-3. 加入了更多的注释，方便大家理解代码
-4. 加入了更多的错误处理，使得代码更加稳定
-5. 加入了更多的功能，如chatgpt4及以上版本的支持
-6. 迁移到 `uv` 管理依赖，并移除了 `langchain` 全家桶，直接调用 `openai` SDK + `chromadb` + `sentence-transformers`
+> 原作者已经暂停维护，目前由我和小伙伴们继续优化。已完成迁移到 [uv](https://docs.astral.sh/uv/) 管理依赖、移除 langchain 全家桶、把浏览器自动化从 Selenium 迁到 [nodriver](https://github.com/ultrafunkamsterdam/nodriver)（绕过 BOSS 反爬更稳）。
 
-我们将要完成的事情：
-1. 加入Electron，开发出前端界面
-2. 可以发送给BOSS附件
+> ⚠️ 请勿用本脚本割韭菜。能被逼到用脚本投简历的人，身上没啥油水可榨。
 
-我们寻求更多的小伙伴加入我们，如果你有兴趣，请联系我，我们一起完善这个项目。
+---
 
-------------------下面是原作者的README---------------------
+## 快速开始（5 分钟）
 
-这是一个完全免费的脚本，只需要你们自己配置好openai的api即可
+### 前置
 
-希望您能给我点个 **star**
+- Python >= 3.11
+- macOS / Linux / Windows（脚本目前只支持 Chrome / Chromium，nodriver 不支持 Edge/Safari）
+- 装好 Chrome（不是 Chromium beta，普通 stable 即可）
+- 装好 [uv](https://docs.astral.sh/uv/)：`curl -LsSf https://astral.sh/uv/install.sh | sh`
 
-如果在这个寒冷的招聘季，这个脚本能给您一些帮助，带来一些温暖，将让我非常荣幸
-
-希望不要有人拿着我的脚本去割韭菜，都已经被逼到用这种脚本投简历的地步了，身上也没啥油水可榨了吧。
-
-## 操作步骤
-
-1. 请首先配置好 openai 的 api（使用.env文件或者在代码中配置）
-2. 将pdf简历上传到文件夹 auto_job_find 里，命名为 **“my_cover.pdf"**
-3. 将需要的包安装好
-4. 执行 write_response.py
-
-5. 请首先配置好openai的api，随后将pdf简历上传到文件夹resume里，命名为“my_cover".随后执行main.py即可
-会自动生成openai的assistant，并在本地产生一个.json文件，只有第一次运行的时候才会产生，后面每次运行如果检测到这个json，就会调用已有的assistant
-
-
-关于openai部分的包：
-openai
-
-About RPA
-tutorial video about how to learn rpa: https://www.youtube.com/watch?v=65OPFmEgCbM&list=PLx4LEkEdFArgrdD_lvXe_hYBy8zM0Sp3b&index=1
-Package of RPA
-selenium
-robotframework
-robotframework-seleniumlibrary
-robotframework-pythonlibcore
-
-Plugin: Intellibot@Selenium Library
-## 关于 asistant
-
-会自动生成 openai 的 asistant，并在本地产生一个 .json 文件，只有第一次运行的时候才会产生，后面每次运行如果检测到这个 json ，就会调用已有的 asistant。
-
-## 使用到的包
-
-依赖统一由 `pyproject.toml` 声明、`uv.lock` 锁定。运行时所需的包：
-`openai`、`python-dotenv`、`selenium`、`pypdf`、`chromadb`、
-`sentence-transformers`、`packaging`。
-
-要求 Python `>=3.11`。`langchain` 已完全移除，DeepSeek / Claude 都通过
-`openai` SDK 加自定义 `base_url` 调用。
-## About RPA
-
-tutorial video about how to learn [rpa](https://www.youtube.com/watch?v=65OPFmEgCbM&list=PLx4LEkEdFArgrdD_lvXe_hYBy8zM0Sp3b&index=1)
-
-Plugin: Intellibot@Selenium Library
-
-------------------下面是简单的教学视频---------------------
-
-[B站链接](https://www.bilibili.com/video/BV1UC4y1N78v/?share_source=copy_web&vd_source=b2608434484091fcc64d4eb85233122d)
-
-[油管链接](https://youtu.be/TlnytEi2lD8?si=jfcDj2MZqBptziZc)
-
-## 运行方式
-
-项目使用 [uv](https://docs.astral.sh/uv/) 管理依赖。先安装 uv
-（`curl -LsSf https://astral.sh/uv/install.sh | sh`），clone 项目，
-然后在项目根目录下执行：
+### 跑起来
 
 ```bash
-uv sync          # 创建 .venv 并安装依赖
-uv run main.py   # 启动 CLI
-```
+# 1. clone + 安装依赖
+git clone https://github.com/longsizhuo/BossZhiPin_Job_Search.git
+cd BossZhiPin_Job_Search
+uv sync
 
-### Assistant 方式运行（OpenAI Assistants API）
-1. 打开 `.env` 配置 `OPENAI_API_KEY`。
-2. 将 pdf 简历放到 `resume` 文件夹，命名为 `my_cover.pdf`。
-3. `uv run main.py`，选项选 `2`。
+# 2. 配 API key
+cp .env.example .env
+# 编辑 .env，至少填一个 LLM provider 的 key（详见下方 .env 字段说明）
 
-这种方式不支持自定义 api，但执行速度更快。
+# 3. 准备简历
+mkdir -p resume
+# 把你的 PDF 简历复制进去，命名 my_cover.pdf
+# 或者在 .env 设 RESUME_PATH 指向别的位置
 
-### DeepSeek / Claude 方式（基于简历向量库的 RAG）
-1. 在 `.env` 配置 `DEEPSEEK_API_KEY`（或者使用 Claude 的话 `ANTHROPIC_API_KEY`）。
-2. 将 pdf 简历放到 `resume` 文件夹，命名为 `my_cover.pdf`。
-3. `uv run main.py`，选项选 `1`（DeepSeek）或 `3`（Claude）。
-
-两家服务都走 OpenAI 兼容端点，所以不需要额外 SDK。
-
-### 安全：dry-run 与审计日志
-
-发送前每封信都会过一次校验（长度区间 + 错误关键词黑名单）。校验失败的信
-**不会发送**，但会照样写日志。
-
-每次生成（无论是真的发出去、被拦截、还是 dry-run）都会追加一行 JSONL 到
-`./logs/letters.jsonl`，包含 JD、生成内容、provider、model。用来复盘事故、
-迭代 prompt：
-
-```bash
-tail -f logs/letters.jsonl | jq '{ts, sent, validation_ok, letter_len}'
-```
-
-不想真的发到 BOSS 的话，用 `DRY_RUN=1` 启动：
-
-```bash
+# 4. dry-run 试一下（只生成、不发送）
 DRY_RUN=1 uv run main.py
+
+# 5. 确认 logs/letters.jsonl 里的招呼语质量 OK，再去掉 DRY_RUN 真跑
+uv run main.py
 ```
 
-Selenium 照常浏览职位、抓 JD、调用 LLM，但不点"立即沟通"按钮。结束后看
-`logs/letters.jsonl` 调 prompt。
+### 首次运行：扫码登录
 
+脚本会用 `./chrome_profile/` 这个独立目录起 Chrome（**不会动你日常浏览器**）。第一次会被 BOSS 重定向到登录页，自动点上"微信扫码"，你扫一次码登录成功后 cookie 留在 `chrome_profile/`，**后续运行都跳过登录**。
 
-### chatgpt4 及以上运行方式
-如果尝试使用更新的chatGPT则不能保持最新版本为`v1.1.1`，同时如果报错信息为`An error occurred: Error code: 400 - {'error': {'message': "The requested model 'gpt-4o-mini' cannot be used with the Assistants API in v1. Follow the migration guide to upgrade to v2: https://platform.openai.com/docs/assistants/migration.", 'type': 'invalid_request_error', 'param': 'model', 'code': 'unsupported_model'}}`
+---
 
-1. 需要手动将chatgpt更新到最新版，
+## `.env` 字段速查
 
-```shell
-pip install --upgrade openai
+仓库根目录的 [`.env.example`](.env.example) 是完整模板，几个关键字段：
+
+| 字段 | 作用 | 必填 |
+|---|---|---|
+| `DEEPSEEK_API_KEY` | DeepSeek key（[申请](https://platform.deepseek.com/api_keys)） | 三选一 |
+| `OPENAI_API_KEY` | OpenAI key，用于 Assistants 模式（[申请](https://platform.openai.com/api-keys)） | 三选一 |
+| `ANTHROPIC_API_KEY` | Anthropic Claude key（[申请](https://console.anthropic.com/settings/keys)） | 三选一 |
+| `BOSS_USR_NAME` | 你的名字，会出现在招呼语署名里 | 否（不填会启动时问你） |
+| `BOSS_LABEL` | 求职 tag，比如"后端开发（成都）" | 否（不填就用 BOSS 默认推荐 feed） |
+| `RESUME_PATH` | 简历 PDF 路径 | 否（默认 `./resume/my_cover.pdf`） |
+| `DRY_RUN` | `1` = 只生成不发送 | 否 |
+| `BOSS_CHROME_PROFILE` | 自定义 Chrome profile 目录 | 否（默认 `./chrome_profile`） |
+| `LETTER_MIN_LEN` / `LETTER_MAX_LEN` | 招呼语长度边界 | 否（默认 30 / 800） |
+| `LETTER_LOG_PATH` | 审计日志路径 | 否（默认 `./logs/letters.jsonl`） |
+
+**只配一个 key 时脚本会自动选用，不会让你选**；配多个时启动时让你选；一个都不配会列出 signup 链接然后退出。
+
+---
+
+## 三种 provider 怎么选
+
+| Provider | 路径 | 优势 | 劣势 |
+|---|---|---|---|
+| DeepSeek | RAG 模式（自建 chroma 向量库 + sentence-transformers 召回简历片段） | 最便宜，质量过得去 | 首次跑会下载 embedding 模型 (~430MB) |
+| OpenAI | Assistants API + Vector Stores（OpenAI 那边管简历向量化） | 不用本地 embedding，省内存 | 每次调用比 DeepSeek 贵不少 |
+| Claude | RAG 模式（同 DeepSeek） | 招呼语风格更自然 | 模型本身贵，但走 RAG 单次 token 少 |
+
+---
+
+## 安全：dry-run + 审计日志
+
+每封生成的招呼语在发送前都会过 [`audit.py`](audit.py) 里的 `validate_letter`：
+- 长度区间检查（默认 30~800 字符）
+- 必须包含中文字符
+- 黑名单关键词（"Error"、"Traceback"、"As an AI"、"```" 等），命中即拦截
+
+无论是发送成功、被拦截还是 dry-run，都会追加一行 JSONL 到 `./logs/letters.jsonl`，包括 JD、生成内容、provider、model、validation 结果。复盘事故 / 调 prompt 用得着：
+
+```bash
+tail -f logs/letters.jsonl | jq '{ts, sent, validation_ok, validation_reasons, letter_len}'
 ```
 
-2. 以及更改`create_assistant`中的结构体，详细参考[迁移模型](https://platform.openai.com/docs/assistants/migration)中的描述。建议直接在[平台](https://platform.openai.com/assistants/)上手动添加最新的assist然后复制代码到`assistant.json`中最为方便.
-```json
-{"assistant_id": "asst_token"}
+---
+
+## Troubleshooting
+
+### 浏览器闪退 / 起不来 / `SessionNotCreatedException`
+旧版本用过 `undetected-chromedriver`，它自带的 chromedriver 跟 Chrome 版本对不齐就崩。本仓库已迁到 [nodriver](https://github.com/ultrafunkamsterdam/nodriver)，**没有 chromedriver**，直接走 CDP，所以这类版本错误结构上不会发生。如果还是闪退，多半是 profile 被锁。
+
+### Chrome 启动后 profile 显示空白 / "好像不是我的 Chrome"
+对，脚本默认用 **独立 profile**（`./chrome_profile/`），不是你日常 Chrome。这是设计——避免影响你日常浏览器的扩展和登录状态。第一次会让你扫码登录 BOSS，之后 cookie 留在这个独立 profile 里。
+
+想用日常 Chrome 的 cookie？把日常 Chrome 完全退出，然后：
+```bash
+BOSS_CHROME_PROFILE="$HOME/Library/Application Support/Google/Chrome" uv run main.py
+```
+**警告**：日常 Chrome 必须先完全关掉（菜单栏 → Quit Google Chrome），不然 profile 会被锁。
+
+### 弹出 newtab、看不到 BOSS 页面
+旧 profile 里有恢复 tab 时会发生。新版本 ([commit `7dbdf37`](https://github.com/longsizhuo/BossZhiPin_Job_Search/commit/7dbdf37)) 起来直接在新窗口里打开 BOSS，已经修了。
+
+### 卡在 "页面已稳定" 之后不动
+应该没了——之前是 `tab.select(timeout=0)` 在 nodriver 里阻塞。如果还遇到，把控制台输出贴 issue 里。
+
+### 提示"❌ 找不到简历文件"
+按提示把 PDF 放到 `./resume/my_cover.pdf`，或者 `.env` 里 `RESUME_PATH=...`。
+
+### 提示"❌ 没找到任何 API key"
+按提示去申请一个填到 `.env`。最少只需要一个。
+
+---
+
+## 项目结构
+
+```
+.
+├── main.py                       # 入口，处理交互/env 校验/路由 provider
+├── models/
+│   ├── llm.py                    # provider 配置 + DeepSeek/Claude 的 chat completions 调用
+│   ├── openai_assistant.py       # OpenAI Assistants 模式（带 vector store 的）
+│   └── prompts.py                # 招呼语 prompt 模板
+├── website_oper/
+│   ├── finding_jobs.py           # 浏览器自动化（nodriver），sync facade + async impl
+│   └── write_response.py         # 单个岗位的主循环：JD → 生成 → 校验 → 发送/日志
+├── vectorization.py              # 简历 PDF 解析 + sentence-transformers 向量化 + Chroma 持久化
+├── audit.py                      # 招呼语校验 + JSONL 审计日志
+└── .env.example                  # 所有环境变量的注释样板
 ```
 
------
-### 以下是原作者的友链：
+---
 
-------------下面是其他朋友基于js构建的更加易于使用的代码---------------
+## 想加入维护？
 
-我一直也在考虑如何可以降低各位的使用门槛，基于现在项目的热度，我发现很多朋友都需要这个东西来帮助自己，但是我相信对于更多的人而言，甚至vpn都是一个障碍
+我们寻求更多小伙伴加入。如果你愿意做：
+- Electron 前端 UI
+- 给 BOSS 发简历附件
+- 投递历史 / 自动跟进
+- 多账号支持
 
-下面这位朋友基于js实现了一个更加简易的版本，虽然因为调用的免费api，无法使用assistant进行retrival，需要自己对简历进行简单的处理，但我依然认为这是个很棒的项目
+发 issue 或者 PR 都行。
 
-感谢朋友的贡献，以下是链接：
+---
 
-[https://github.com/noBaldAaa](https://github.com/noBaldAaa/find-job)https://github.com/noBaldAaa/find-job
+## 致谢
 
-------------下面是其他朋友基于azure的openai api构建的版本的更加易于使用的代码---------------
-https://github.com/LouisCaixuran/auto_job_find_azure
+感谢所有支持本项目的人：
+
+<p align="left">
+    <a href="https://github.com/longsizhuo/BossZhiPin_Job_Search/graphs/contributors">
+        <img width="770" src="https://contrib.rocks/image?repo=longsizhuo/BossZhiPin_Job_Search&max=300&columns=16" />
+    </a>
+</p>
+
+### 衍生项目
+
+- [noBaldAaa/find-job](https://github.com/noBaldAaa/find-job) — 基于 JS 的更简版本
+- [LouisCaixuran/auto_job_find_azure](https://github.com/LouisCaixuran/auto_job_find_azure) — 基于 Azure OpenAI 的版本

--- a/main.py
+++ b/main.py
@@ -1,52 +1,117 @@
 import os
+import sys
+from pathlib import Path
 
+from dotenv import load_dotenv
 from openai import OpenAI
-from packaging import version
-import openai
 
 from models.openai_assistant import create_assistant, OPENAI_API_KEY
 from vectorization import embed_pdf
 from website_oper.write_response import send_job_descriptions_to_chat
 
-if __name__ == '__main__':
+load_dotenv()
+
+PROVIDER_ENV_KEYS: dict[str, str] = {
+    "deepseek": "DEEPSEEK_API_KEY",
+    "chatgpt": "OPENAI_API_KEY",
+    "claude": "ANTHROPIC_API_KEY",
+}
+
+PROVIDER_SIGNUP: dict[str, str] = {
+    "deepseek": "https://platform.deepseek.com/api_keys",
+    "chatgpt": "https://platform.openai.com/api-keys",
+    "claude": "https://console.anthropic.com/settings/keys",
+}
+
+
+def detect_providers() -> list[str]:
+    return [name for name, env in PROVIDER_ENV_KEYS.items() if os.getenv(env)]
+
+
+def pick_provider() -> str:
+    available = detect_providers()
+    if not available:
+        print("❌ 没在环境里找到任何 LLM provider 的 API key。")
+        print("   去这些地方申请一个填进 .env（仓库里有 .env.example 可以参考）：")
+        for name, url in PROVIDER_SIGNUP.items():
+            print(f"     • {PROVIDER_ENV_KEYS[name]:<22} {url}")
+        sys.exit(1)
+    if len(available) == 1:
+        provider = available[0]
+        print(f"✅ 检测到只配了 {PROVIDER_ENV_KEYS[provider]}，自动选用：{provider}")
+        return provider
+    print(f"检测到 {len(available)} 个 provider 都配了 key，请选一个：")
+    for i, name in enumerate(available, 1):
+        print(f"  {i}. {name:<10} ({PROVIDER_ENV_KEYS[name]})")
+    while True:
+        choice = input(f"输入序号 (1-{len(available)}): ").strip()
+        if choice.isdigit() and 1 <= int(choice) <= len(available):
+            return available[int(choice) - 1]
+        print("无效输入，再试一次")
+
+
+def ensure_usr_name() -> str:
+    name = os.getenv("BOSS_USR_NAME", "").strip()
+    if name:
+        return name
+    while True:
+        name = input("请输入你的名字（用于打招呼语结尾的署名）: ").strip()
+        if name:
+            return name
+        print("不能为空")
+
+
+def ensure_resume_path() -> str:
+    resume_path = os.getenv("RESUME_PATH", "").strip() or "resume/my_cover.pdf"
+    if not Path(resume_path).is_file():
+        print(f"❌ 找不到简历文件：{resume_path}")
+        print(f"   请把 PDF 简历放到这个路径，或者在 .env 设 RESUME_PATH 指向其他位置。")
+        sys.exit(1)
+    return resume_path
+
+
+def get_label() -> str:
+    """求职 tag 是可选的——为空就让 BOSS 给默认推荐 feed。"""
+    return os.getenv("BOSS_LABEL", "").strip()
+
+
+if __name__ == "__main__":
     dry_run = os.getenv("DRY_RUN", "").lower() in ("1", "true", "yes")
     if dry_run:
-        print("⚠️  DRY_RUN=1 — letters will be generated and logged but NOT sent to BOSS.")
+        print("⚠️  DRY_RUN=1 — 招呼语只会生成 + 写日志，不会真的发到 BOSS")
 
-    while True:
-        model = input("Which model do you want to use? (deepseek: 1, chatgpt: 2, Claud: 3): ")
-        if model not in ["1", "2", "3"]:
-            print("Invalid model. Please enter either 'deepseek', 'chatgpt', or 'Claud'.")
-        else:
-            break
+    provider = pick_provider()
+    usr_name = ensure_usr_name()
+    resume_path = ensure_resume_path()
+    label = get_label()
+    if label:
+        print(f"求职 tag：{label}")
+    else:
+        print("没设 BOSS_LABEL，用 BOSS 默认推荐 feed")
 
     url = "https://www.zhipin.com/web/geek/job-recommend?ka=header-job-recommend"
     browser_type = "chrome"
-    label = "后端开发（成都）"  # 想要选择的下拉菜单项
-    usr_name = "龙思卓"  # 用户名
 
-    if model == "1":
-        # DeepSeek
-        vectorstore = embed_pdf("resume/my_cover.pdf", "./vectorstores")
-        send_job_descriptions_to_chat(usr_name, url, browser_type, label, "deepseek", vectorstore=vectorstore, dry_run=dry_run)
-
-    elif model == "2":
-        chatgpt_model = {1: "gpt-4o", 2: "gpt-4o-turbo"}[int(input("Which ChatGPT model do you want to use? (gpt-4o: 1, gpt-4o-turbo: 2): "))]
-        # Check version compatibility
-        required_version = version.parse("1.1.1")
-        current_version = version.parse(openai.__version__)
-        # Check OpenAI version compatibility
-        if current_version < required_version:
-            raise ValueError(
-                f"Error: OpenAI version {openai.__version__} is less than the required version 1.1.1"
-            )
-        else:
-            print("OpenAI version is compatible.")
-        # It will come from frontend
+    if provider == "deepseek":
+        vectorstore = embed_pdf(resume_path, "./vectorstores")
+        send_job_descriptions_to_chat(
+            usr_name, url, browser_type, label, "deepseek",
+            vectorstore=vectorstore, dry_run=dry_run,
+        )
+    elif provider == "chatgpt":
+        chatgpt_model = os.getenv("CHATGPT_MODEL", "").strip() or "gpt-4o"
+        print(f"OpenAI 模型：{chatgpt_model}（可用 CHATGPT_MODEL 环境变量覆盖）")
         client_openAI = OpenAI(api_key=OPENAI_API_KEY)
-        assistant_id = create_assistant(usr_name, chatgpt_model ,client_openAI)
-        send_job_descriptions_to_chat(usr_name, url, browser_type, label, "chatgpt", client_openAI=client_openAI, assistant_id=assistant_id, dry_run=dry_run)
-    elif model == "3":
-        # Claude via OpenAI-compatible endpoint
-        vectorstore = embed_pdf("resume/my_cover.pdf", "./vectorstores")
-        send_job_descriptions_to_chat(usr_name, url, browser_type, label, "claude", vectorstore=vectorstore, dry_run=dry_run)
+        assistant_id = create_assistant(
+            usr_name, chatgpt_model, client_openAI, resume_path=resume_path
+        )
+        send_job_descriptions_to_chat(
+            usr_name, url, browser_type, label, "chatgpt",
+            client_openAI=client_openAI, assistant_id=assistant_id, dry_run=dry_run,
+        )
+    elif provider == "claude":
+        vectorstore = embed_pdf(resume_path, "./vectorstores")
+        send_job_descriptions_to_chat(
+            usr_name, url, browser_type, label, "claude",
+            vectorstore=vectorstore, dry_run=dry_run,
+        )

--- a/main.py
+++ b/main.py
@@ -101,7 +101,13 @@ if __name__ == "__main__":
     elif provider == "chatgpt":
         chatgpt_model = os.getenv("CHATGPT_MODEL", "").strip() or "gpt-4o"
         print(f"OpenAI 模型：{chatgpt_model}（可用 CHATGPT_MODEL 环境变量覆盖）")
-        client_openAI = OpenAI(api_key=OPENAI_API_KEY)
+        openai_base_url = os.getenv("OPENAI_BASE_URL", "").strip()
+        if openai_base_url:
+            print(f"OpenAI base_url 覆盖：{openai_base_url}")
+        client_openAI = OpenAI(
+            api_key=OPENAI_API_KEY,
+            base_url=openai_base_url or None,
+        )
         assistant_id = create_assistant(
             usr_name, chatgpt_model, client_openAI, resume_path=resume_path
         )

--- a/models/openai_assistant.py
+++ b/models/openai_assistant.py
@@ -1,58 +1,60 @@
 import json
 import os
+from pathlib import Path
 
-from openai import OpenAI
-from models.prompts import assistant_instructions
 from dotenv import load_dotenv
+
+from models.prompts import assistant_instructions
 
 load_dotenv()
 
-OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
-OPENAI_BASE_URL = os.getenv('OPENAI_BASE_URL')
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL")
+
+DEFAULT_RESUME_PATH = "resume/my_cover.pdf"
+ASSISTANT_FILE_PATH = "assistant.json"
 
 
-# Create or load assistant
-def create_assistant(usr_name, chatgpt_model, client):
-    assistant_file_path = '../assistant.json'
+def create_assistant(usr_name, chatgpt_model, client, resume_path: str | None = None):
+    """Create (or load) an OpenAI Assistant backed by the user's PDF resume.
 
-    # If there is an assistant.json file already, then load that assistant
-    if os.path.exists(assistant_file_path):
-        with open(assistant_file_path, 'r') as file:
+    ``resume_path`` defaults to ``./resume/my_cover.pdf``; pass the path resolved
+    from the ``RESUME_PATH`` env var (or wherever) to override it.
+    """
+    resume_path = resume_path or DEFAULT_RESUME_PATH
+
+    if os.path.exists(ASSISTANT_FILE_PATH):
+        with open(ASSISTANT_FILE_PATH, "r") as file:
             assistant_data = json.load(file)
-            assistant_id = assistant_data['assistant_id']
-            print("Loaded existing assistant ID.")
-    else:
-        # If no assistant.json is present, create a new assistant using the below specifications
+            print(f"Loaded existing assistant ID from {ASSISTANT_FILE_PATH}")
+            return assistant_data["assistant_id"]
 
-        # To change the knowledge document, modify the file name below to match your document If you want to add
-        # multiple files, paste this function into ChatGPT and ask for it to add support for multiple files
-        # file = client.files.create(file=open("resume/my_cover.pdf", "rb"),
-        #                            purpose='assistants')
-        vector_store = client.vector_stores.create(name="My Resume")
-        print(vector_store)
-        file_streams = [open("./resume/my_cover.pdf", "rb")]
-        # Use the upload and poll SDK helper to upload the files, add them to the vector store,
-        # and poll the status of the file batch for completion.
-        file_batch = client.vector_stores.file_batches.upload_and_poll(
-            vector_store_id=vector_store.id, files=file_streams
-        )
-        # New version of the assistant
-        assistant = client.beta.assistants.create(
-            instructions=assistant_instructions(usr_name),
-            model=chatgpt_model,
-            tools=[{"type": "file_search"}],
+    if not Path(resume_path).is_file():
+        raise FileNotFoundError(
+            f"简历文件不存在：{resume_path}。把 PDF 放到这个路径，"
+            f"或者在 .env 里设 RESUME_PATH 指向其他位置。"
         )
 
-        assistant = client.beta.assistants.update(
-            assistant_id=assistant.id,
-            tool_resources={"file_search": {"vector_store_ids": [vector_store.id]}},
+    vector_store = client.vector_stores.create(name="My Resume")
+    print(f"Created OpenAI vector store: {vector_store.id}")
+
+    with open(resume_path, "rb") as resume_file:
+        client.vector_stores.file_batches.upload_and_poll(
+            vector_store_id=vector_store.id, files=[resume_file]
         )
 
-        # Create a new assistant.json file to load on future runs
-        with open(assistant_file_path, 'w') as file:
-            json.dump({'assistant_id': assistant.id}, file)
-            print("Created a new assistant and saved the ID.")
+    assistant = client.beta.assistants.create(
+        instructions=assistant_instructions(usr_name),
+        model=chatgpt_model,
+        tools=[{"type": "file_search"}],
+    )
+    assistant = client.beta.assistants.update(
+        assistant_id=assistant.id,
+        tool_resources={"file_search": {"vector_store_ids": [vector_store.id]}},
+    )
 
-        assistant_id = assistant.id
+    with open(ASSISTANT_FILE_PATH, "w") as file:
+        json.dump({"assistant_id": assistant.id}, file)
+        print(f"Created a new assistant, saved ID to {ASSISTANT_FILE_PATH}")
 
-    return assistant_id
+    return assistant.id

--- a/website_oper/finding_jobs.py
+++ b/website_oper/finding_jobs.py
@@ -189,8 +189,11 @@ async def _select_dropdown_option_impl(label: str) -> None:
     print(f"  路径 3: fallback —— 用 BOSS 默认的推荐 feed 继续（不主动选 tag）")
 
 
-def select_dropdown_option(_unused_driver, label: str) -> None:
-    """保留旧签名（第一个参数曾经是 driver）方便 write_response.py 渐进迁移。"""
+def select_dropdown_option(label: str) -> None:
+    """空 label 表示用 BOSS 默认推荐 feed，不主动选 tag。"""
+    if not label:
+        print("[select_dropdown_option] label 为空，沿用当前推荐 feed")
+        return
     _run(_select_dropdown_option_impl(label))
 
 

--- a/website_oper/write_response.py
+++ b/website_oper/write_response.py
@@ -99,6 +99,10 @@ def send_job_descriptions_to_chat(
 
     job_index = 1
     iteration = 0
+    consecutive_misses = 0
+    # 推荐 feed 末尾、或者某条岗位卡 DOM 没渲染好，都会让 get_job_description
+    # 返回 None。连续 N 次拿不到就当列表到底了停掉，否则 job_index 会无限涨。
+    MAX_CONSECUTIVE_MISSES = 5
     # 第一轮按 label（如果有的话）筛 tag；后续轮次留在当前 feed，无需重复点
     finding_jobs.select_dropdown_option(label)
     while True:
@@ -107,6 +111,7 @@ def send_job_descriptions_to_chat(
             print(f"\n=== 第 {iteration} 轮: 处理 job_index={job_index} ===")
             job_description = finding_jobs.get_job_description_by_index(job_index)
             if job_description:
+                consecutive_misses = 0
                 element = finding_jobs.get_text_by_css(".op-btn.op-btn-chat")
                 print(f"chat 按钮文字: {element!r}")
                 if element == "立即沟通":
@@ -162,6 +167,15 @@ def send_job_descriptions_to_chat(
                             dry_run=False,
                             sent=True,
                         )
+            else:
+                consecutive_misses += 1
+                print(f"job_index={job_index} 拿不到 JD（连续第 {consecutive_misses} 次）")
+                if consecutive_misses >= MAX_CONSECUTIVE_MISSES:
+                    print(
+                        f"连续 {MAX_CONSECUTIVE_MISSES} 个岗位拿不到，"
+                        f"推测已到推荐 feed 列表底部，结束"
+                    )
+                    break
 
             time.sleep(3)
             job_index += 1

--- a/website_oper/write_response.py
+++ b/website_oper/write_response.py
@@ -1,8 +1,9 @@
 import json
+import re
 import time
-from models.llm import PROVIDERS, generate_letter
 
 from audit import log_attempt, validate_letter
+from models.llm import PROVIDERS, generate_letter
 from website_oper import finding_jobs
 
 
@@ -17,7 +18,7 @@ def create_thread(client):
         return None
 
 
-def chat(user_input, assistant_id, client, thread_id=None):
+def chat(user_input, assistant_id, client, usr_name: str = "", thread_id=None):
     if thread_id is None:
         thread_id = create_thread(client)
         if thread_id is None:
@@ -25,53 +26,35 @@ def chat(user_input, assistant_id, client, thread_id=None):
 
     print(f"Received message: {user_input} in thread {thread_id}")
 
-    # Run the Assistant
     try:
-        # Add the user's message to the thread
         client.beta.threads.messages.create(
-            thread_id=thread_id,
-            role="user",
-            content=user_input
+            thread_id=thread_id, role="user", content=user_input
         )
-
-        # Start the Assistant Run
         run = client.beta.threads.runs.create(
-            thread_id=thread_id,
-            assistant_id=assistant_id
+            thread_id=thread_id, assistant_id=assistant_id
         )
 
-        # Check if the Run requires action (function call)
         while True:
             run_status = client.beta.threads.runs.retrieve(
-                thread_id=thread_id,
-                run_id=run.id,
-                timeout=60  # 设置超时时间为60秒
+                thread_id=thread_id, run_id=run.id, timeout=60
             )
-
-            if run_status.status == 'completed':
+            if run_status.status == "completed":
                 break
-            elif run_status.status == 'requires_action':
-                # Here you can handle specific actions if your assistant requires them
-                # ...
-                time.sleep(1)  # Wait for a second before checking again
+            if run_status.status == "requires_action":
+                time.sleep(1)
 
-        # Retrieve and return the latest message from the assistant
         messages = client.beta.threads.messages.list(thread_id=thread_id)
         assistant_message = messages.data[0].content[0].text.value
 
-        # 将换行符替换为一个空格
-        formatted_message = assistant_message.replace("\n", " ").replace(" ", "").replace("真诚的，龙思卓", "")
-        import re
-        formatted_message = re.sub(r'【.*?】', '', formatted_message)
-
-
-        # response_data = json.dumps({"response": assistant_message, "thread_id": thread_id})
+        formatted_message = assistant_message.replace("\n", " ").replace(" ", "")
+        if usr_name:
+            formatted_message = formatted_message.replace(f"真诚的，{usr_name}", "")
+        formatted_message = re.sub(r"【.*?】", "", formatted_message)
         return formatted_message
 
     except Exception as e:
         print(f"An error occurred: {e}")
-        error_response = json.dumps({"error": str(e)})
-        return error_response
+        return json.dumps({"error": str(e)})
 
 
 def send_response_and_go_back(response):
@@ -105,11 +88,12 @@ def send_job_descriptions_to_chat(
 
     job_index = 1
     iteration = 0
+    # 第一轮按 label（如果有的话）筛 tag；后续轮次留在当前 feed，无需重复点
+    finding_jobs.select_dropdown_option(label)
     while True:
         try:
             iteration += 1
             print(f"\n=== 第 {iteration} 轮: 处理 job_index={job_index} ===")
-            finding_jobs.select_dropdown_option(None, label)
             job_description = finding_jobs.get_job_description_by_index(job_index)
             if job_description:
                 element = finding_jobs.get_text_by_css(".op-btn.op-btn-chat")
@@ -118,7 +102,12 @@ def send_job_descriptions_to_chat(
                     if models in ("deepseek", "claude"):
                         response = generate_letter(usr_name, vectorstore, job_description, model=models)
                     else:
-                        response = chat(user_input=job_description, client=client_openAI, assistant_id=assistant_id)
+                        response = chat(
+                            user_input=job_description,
+                            client=client_openAI,
+                            assistant_id=assistant_id,
+                            usr_name=usr_name,
+                        )
 
                     validation = validate_letter(response)
                     resolved_model = _resolve_model_name(models, assistant_id)
@@ -164,7 +153,7 @@ def send_job_descriptions_to_chat(
                         )
 
             time.sleep(3)
-            # job_index += 1
+            job_index += 1
 
         except Exception as e:
             print(f"An error occurred: {e}")

--- a/website_oper/write_response.py
+++ b/website_oper/write_response.py
@@ -34,14 +34,25 @@ def chat(user_input, assistant_id, client, usr_name: str = "", thread_id=None):
             thread_id=thread_id, assistant_id=assistant_id
         )
 
+        # 等 run 完成。原来这里在 queued / in_progress 时直接 busy-loop 不 sleep，
+        # 单次招呼可以打几万次 API；同时 failed / cancelled / expired 没处理，
+        # 命中就是死循环。加上 5 分钟硬超时 + 每轮 1s sleep + 终态识别。
+        TERMINAL_FAIL_STATES = {"failed", "cancelled", "expired", "incomplete"}
+        deadline = time.time() + 300
         while True:
             run_status = client.beta.threads.runs.retrieve(
                 thread_id=thread_id, run_id=run.id, timeout=60
             )
             if run_status.status == "completed":
                 break
-            if run_status.status == "requires_action":
-                time.sleep(1)
+            if run_status.status in TERMINAL_FAIL_STATES:
+                err = f"OpenAI run 进入失败终态：{run_status.status}"
+                print(f"[chat] {err}")
+                return json.dumps({"error": err})
+            if time.time() > deadline:
+                print("[chat] run 等待超过 5 分钟，放弃")
+                return json.dumps({"error": "run timeout (>300s)"})
+            time.sleep(1)
 
         messages = client.beta.threads.messages.list(thread_id=thread_id)
         assistant_message = messages.data[0].content[0].text.value


### PR DESCRIPTION
## Summary

Full code review pass for first-time-user friendliness. Five commits, no behavior changes to the browser-automation core — everything here is onboarding, configuration, and dead-code cleanup.

Before this PR a fresh clone needed: (1) editing `main.py` to set the user's name and job tag, (2) guessing which env vars existed by grepping `models/llm.py`, (3) selecting from a 1/2/3 menu even when only one API key was configured, (4) putting the resume at a path that the README spelled wrong, and (5) reading three different README sections to learn that Edge/Safari were never actually supported.

## What changed

| Commit | What |
|---|---|
| [`1f968b5`](https://github.com/longsizhuo/BossZhiPin_Job_Search/commit/1f968b5) | Add `.env.example` — every env var the codebase reads, with signup URLs and provider tradeoffs in comments. |
| [`3b65b75`](https://github.com/longsizhuo/BossZhiPin_Job_Search/commit/3b65b75) | Fix `create_assistant`: real `assistant.json` path (was `'../assistant.json'`, only worked from `models/`), accept a `resume_path` argument, friendly error when the PDF is missing. |
| [`326fbe1`](https://github.com/longsizhuo/BossZhiPin_Job_Search/commit/326fbe1) | `main.py` overhaul. Auto-detects which provider keys are in `.env` (one → use it, multiple → ask, zero → list signup URLs and exit). `BOSS_USR_NAME` / `BOSS_LABEL` / `RESUME_PATH` / `CHATGPT_MODEL` env-var escape hatches for everything previously hardcoded as my own info. Drops the 2023-era openai-version compatibility check and the `gpt-4o-turbo` model name that never existed. |
| [`45136c7`](https://github.com/longsizhuo/BossZhiPin_Job_Search/commit/45136c7) | Uncomment `job_index += 1` (loop had been processing job #1 forever). Drop the unused `driver` parameter from `select_dropdown_option`. Replace the hardcoded `"真诚的，龙思卓"` signature scrub in `chat()` with a `usr_name`-driven version. |
| [`d750227`](https://github.com/longsizhuo/BossZhiPin_Job_Search/commit/d750227) | Rewrite both READMEs end-to-end. Accurate 5-minute Quick Start, full `.env` field table, provider comparison, dry-run + audit-log story, and a Troubleshooting section that points at the actual commits that fixed each problem. |

## Test plan

- [x] Fresh checkout: `cp .env.example .env`, fill **only** `DEEPSEEK_API_KEY`, run `DRY_RUN=1 uv run main.py`. Expect no provider menu, prompt for name (because `BOSS_USR_NAME` unset), then proceed.
- [x] Same but with `BOSS_USR_NAME=xxx` and `BOSS_LABEL=xxx` in `.env` — should run with zero prompts.
- [x] With no resume at `resume/my_cover.pdf` — expect the "❌ 找不到简历文件" message, not a pypdf traceback.
- [x] With **no** keys in `.env` — expect the signup-URL list and a clean exit.
- [x] With two keys in `.env` — expect the choice menu.
- [x] Sanity-check the README's Quick Start commands actually work from a clean clone.

## Out of scope

- Browser-automation behaviour (just stabilised it in the prior commit chain on master — don't churn).
- `models/llm.py`, `audit.py`, `vectorization.py` — already in good shape.
- Adding new features (resume attachments, follow-ups, multi-account). Listed under "Help wanted" in the new README.