### PR TITLE
feat: 新增两层职位匹配过滤（关键词 + LLM 评分）

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ import nodriver as uc
 from dotenv import load_dotenv
 from openai import OpenAI
 
+from models.job_matcher import extract_keywords_from_resume, extract_resume_text
 from models.openai_assistant import OPENAI_API_KEY, create_assistant
 from vectorization import embed_pdf
 from website_oper.write_response import send_job_descriptions_to_chat
@@ -116,6 +117,11 @@ if __name__ == "__main__":
     url = "https://www.zhipin.com/web/geek/job-recommend?ka=header-job-recommend"
     browser_type = "chrome"
 
+    # 从简历自动提取关键词和全文（用于职位匹配过滤）
+    resume_keywords = extract_keywords_from_resume(resume_path)
+    resume_text = extract_resume_text(resume_path)
+    print(f"📋 从简历中提取到 {len(resume_keywords)} 个关键词: {resume_keywords}")
+
     # send_job_descriptions_to_chat 是 async 的（整段必须跑在同一个事件循环里，
     # 否则 nodriver CDP 会在 run_until_complete 之间进入半死态导致 evaluate hang）。
     # 这里用 ``uc.loop().run_until_complete(...)`` 一次性跑完。
@@ -124,6 +130,8 @@ if __name__ == "__main__":
         uc.loop().run_until_complete(send_job_descriptions_to_chat(
             usr_name, url, browser_type, label, "deepseek",
             vectorstore=vectorstore, dry_run=dry_run,
+            resume_keywords=resume_keywords, resume_text=resume_text,
+            min_llm_score=50,
         ))
     elif provider == "chatgpt":
         chatgpt_model = os.getenv("CHATGPT_MODEL", "").strip() or "gpt-4o"
@@ -141,10 +149,14 @@ if __name__ == "__main__":
         uc.loop().run_until_complete(send_job_descriptions_to_chat(
             usr_name, url, browser_type, label, "chatgpt",
             client_openAI=client_openAI, assistant_id=assistant_id, dry_run=dry_run,
+            resume_keywords=resume_keywords, resume_text=resume_text,
+            min_llm_score=50,
         ))
     elif provider == "claude":
         vectorstore = embed_pdf(resume_path, "./vectorstores")
         uc.loop().run_until_complete(send_job_descriptions_to_chat(
             usr_name, url, browser_type, label, "claude",
             vectorstore=vectorstore, dry_run=dry_run,
+            resume_keywords=resume_keywords, resume_text=resume_text,
+            min_llm_score=50,
         ))

--- a/models/job_matcher.py
+++ b/models/job_matcher.py
@@ -1,0 +1,165 @@
+"""
+职位匹配模块：两层过滤
+第一层：关键词匹配（粗筛）- 从简历自动提取关键词，与 JD 对比
+第二层：LLM 评分（精筛）- 让 LLM 评估简历与 JD 的匹配度 0-100
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+
+from dotenv import load_dotenv
+from pypdf import PdfReader
+
+load_dotenv()
+log = logging.getLogger(__name__)
+
+# 预定义的职位类型关键词库，用于从简历中识别技能和方向
+TECH_KEYWORDS = [
+    # 开发方向
+    "后端开发", "前端开发", "全栈开发", "移动开发", "客户端开发",
+    "iOS开发", "Android开发", "嵌入式开发", "游戏开发", "小程序开发",
+    # 技术栈
+    "Python", "Java", "JavaScript", "TypeScript", "Go", "Golang",
+    "C++", "C#", "Rust", "PHP", "Ruby", "Swift", "Kotlin", "Scala",
+    "React", "Vue", "Angular", "Node.js", "Django", "Flask", "FastAPI",
+    "Spring", "SpringBoot", "Spring Boot", "MyBatis", "Hibernate",
+    ".NET", "Flutter", "React Native", "UniApp",
+    # 数据与AI
+    "数据分析", "数据开发", "数据挖掘", "数据仓库", "大数据",
+    "机器学习", "深度学习", "自然语言处理", "NLP", "计算机视觉", "CV",
+    "人工智能", "AI", "LLM", "大模型", "AIGC", "RAG",
+    "数据库", "MySQL", "PostgreSQL", "MongoDB", "Redis", "Elasticsearch",
+    "Hadoop", "Spark", "Flink", "Kafka", "Hive",
+    # 运维与云
+    "运维", "DevOps", "SRE", "云计算", "云原生",
+    "Docker", "Kubernetes", "K8s", "AWS", "Azure", "GCP", "阿里云", "腾讯云",
+    "Linux", "CI/CD", "Jenkins", "Terraform",
+    # 测试
+    "测试", "自动化测试", "性能测试", "测试开发", "QA",
+    "Selenium", "Pytest", "JUnit",
+    # 产品与设计
+    "产品经理", "项目管理", "UI设计", "UX设计", "交互设计",
+    # 安全
+    "网络安全", "信息安全", "安全开发", "渗透测试",
+    # 通用技能
+    "微服务", "分布式", "高并发", "高可用", "消息队列",
+    "RESTful", "API", "GraphQL", "gRPC", "WebSocket",
+    "Git", "Agile", "Scrum",
+]
+
+
+def extract_resume_text(pdf_path: str) -> str:
+    """从 PDF 简历中提取全文文本。"""
+    reader = PdfReader(pdf_path)
+    return "\n".join(page.extract_text() or "" for page in reader.pages)
+
+
+def extract_keywords_from_resume(pdf_path: str) -> list[str]:
+    """从简历 PDF 中自动提取关键词，大小写不敏感。"""
+    resume_text = extract_resume_text(pdf_path)
+    resume_upper = resume_text.upper()
+    return [kw for kw in TECH_KEYWORDS if kw.upper() in resume_upper]
+
+
+def keyword_match(
+    job_description: str,
+    resume_keywords: list[str],
+    min_match: int = 2,
+) -> tuple[bool, list[str]]:
+    """第一层：关键词粗筛。JD 中至少命中 min_match 个简历关键词才通过。"""
+    jd_upper = job_description.upper()
+    matched = [kw for kw in resume_keywords if kw.upper() in jd_upper]
+    return len(matched) >= min_match, matched
+
+
+def llm_match_score(
+    job_description: str,
+    resume_text: str,
+    matched_keywords: list[str],
+) -> tuple[int, str]:
+    """第二层：LLM 精筛。评估简历与职位的匹配度，返回 0-100 分。"""
+    from openai import OpenAI
+
+    api_key = os.getenv("DEEPSEEK_API_KEY")
+    if not api_key:
+        log.warning("DEEPSEEK_API_KEY 未设置，跳过 LLM 评分")
+        return 100, "无法评分（缺少 API key）"
+
+    client = OpenAI(api_key=api_key, base_url="https://api.deepseek.com")
+
+    prompt = f"""你是一位专业的招聘匹配分析师。请评估以下简历与职位描述的匹配程度。
+
+## 职位描述
+{job_description}
+
+## 简历内容
+{resume_text[:2000]}
+
+## 已匹配的关键词
+{', '.join(matched_keywords)}
+
+## 要求
+请严格按以下格式回复，不要包含任何其他内容：
+分数: [0-100的整数]
+理由: [一句话说明，不超过50字]
+
+评分标准：
+- 90-100: 技能和经验高度匹配，非常适合
+- 70-89: 大部分技能匹配，值得投递
+- 50-69: 部分匹配，可以尝试
+- 0-49: 匹配度低，不建议投递"""
+
+    try:
+        response = client.chat.completions.create(
+            model="deepseek-chat",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.1,
+            max_tokens=200,
+        )
+        content = response.choices[0].message.content or ""
+    except Exception as e:
+        log.warning("LLM 评分调用失败: %s", e)
+        return 100, f"评分失败（{e}）"
+
+    score = 0
+    reason = ""
+    score_match = re.search(r"分数:\s*(\d+)", content)
+    reason_match = re.search(r"理由:\s*(.+)", content)
+    if score_match:
+        score = min(100, max(0, int(score_match.group(1))))
+    if reason_match:
+        reason = reason_match.group(1).strip()
+
+    return score, reason
+
+
+def should_apply(
+    job_description: str,
+    resume_keywords: list[str],
+    resume_text: str,
+    min_keyword_match: int = 2,
+    min_llm_score: int = 70,
+) -> tuple[bool, dict]:
+    """两层过滤：先关键词粗筛，再 LLM 精筛。"""
+    keyword_passed, matched_keywords = keyword_match(
+        job_description, resume_keywords, min_keyword_match
+    )
+
+    if not keyword_passed:
+        return False, {
+            "stage": "keyword",
+            "matched_keywords": matched_keywords,
+            "reason": f"关键词匹配不足（命中 {len(matched_keywords)}/{min_keyword_match}）",
+        }
+
+    score, reason = llm_match_score(job_description, resume_text, matched_keywords)
+
+    return score >= min_llm_score, {
+        "stage": "llm",
+        "matched_keywords": matched_keywords,
+        "score": score,
+        "reason": reason,
+        "threshold": min_llm_score,
+    }

--- a/website_oper/write_response.py
+++ b/website_oper/write_response.py
@@ -28,6 +28,7 @@ import time
 
 from audit import log_attempt, validate_letter
 from audit.telemetry import record_llm_call
+from models.job_matcher import should_apply
 from models.llm import PROVIDERS, generate_letter
 from website_oper import finding_jobs
 
@@ -176,6 +177,10 @@ async def send_job_descriptions_to_chat(
     assistant_id=None,
     vectorstore=None,
     dry_run: bool = False,
+    resume_keywords: list[str] | None = None,
+    resume_text: str | None = None,
+    min_keyword_match: int = 2,
+    min_llm_score: int = 70,
 ) -> None:
     """主循环（async）。
 
@@ -209,6 +214,33 @@ async def send_job_descriptions_to_chat(
                 element = await finding_jobs.get_text_by_css(".op-btn.op-btn-chat")
                 log.info("chat 按钮文字: %r", element)
                 if element == "立即沟通":
+                    # ====== 两层过滤：关键词匹配 + LLM 评分 ======
+                    if resume_keywords and resume_text:
+                        apply, details = await asyncio.to_thread(
+                            should_apply,
+                            job_description, resume_keywords, resume_text,
+                            min_keyword_match, min_llm_score,
+                        )
+                        if not apply:
+                            stage = details.get("stage", "unknown")
+                            if stage == "keyword":
+                                log.info(
+                                    "⏭️ [跳过 #%d] 关键词匹配不足: 命中 %s - %s",
+                                    job_index, details["matched_keywords"], details["reason"],
+                                )
+                            else:
+                                log.info(
+                                    "⏭️ [跳过 #%d] LLM 评分 %s/%s: %s",
+                                    job_index, details["score"], details["threshold"], details["reason"],
+                                )
+                            job_index += 1
+                            await asyncio.sleep(3)
+                            continue
+                        log.info("✅ [匹配 #%d] 关键词命中: %s", job_index, details["matched_keywords"])
+                        if details.get("score"):
+                            log.info("   LLM 评分: %s/100 - %s", details["score"], details["reason"])
+                    # ====== 过滤结束 ======
+
                     # LLM 调用是同步阻塞的 HTTP 请求，扔到 thread pool 跑
                     # 避免阻塞事件循环 → 卡死 nodriver CDP heartbeat
                     if models in ("deepseek", "claude"):


### PR DESCRIPTION
## Summary
- 新增 `models/job_matcher.py`：两层职位匹配过滤模块
- 投递前自动检查职位是否匹配简历，避免无差别海投

## 实现方式

### 第一层：关键词粗筛
- 启动时从简历 PDF 自动提取技术关键词（80+ 预定义词库，覆盖开发方向、技术栈、数据/AI、运维、测试等）
- 每个 JD 至少命中 2 个简历关键词才继续（`min_keyword_match` 可配置）
- 不命中直接跳过，不消耗 API 调用

### 第二层：LLM 精筛
- 通过关键词粗筛的职位，调 DeepSeek 评估简历与 JD 的匹配度（0-100 分）
- ≥50 分才投递（`min_llm_score` 可配置）
- `temperature=0.1` 保证评分一致性
- API 调用失败时默认放行（100 分），避免因评分故障漏掉好职位

### 与主循环的集成
- 过滤逻辑插入在"立即沟通"判断之后、生成求职信之前
- 用 `asyncio.to_thread` 包装 LLM 调用，避免阻塞 nodriver CDP 事件循环
- 所有参数都有默认值，不传 `resume_keywords` 时跟原来一样不过滤

## 改动文件
- `models/job_matcher.py`（新增）：关键词提取 + 匹配 + LLM 评分
- `main.py`：启动时提取简历关键词，传入主循环
- `website_oper/write_response.py`：主循环中插入两层过滤逻辑

## 运行时输出示例
```
📋 从简历中提取到 12 个关键词: ['后端开发', 'Python', 'Django', ...]
⏭️ [跳过 #1] 关键词匹配不足: 命中 ['Python'] - 关键词匹配不足（命中 1/2）
✅ [匹配 #2] 关键词命中: ['Python', 'Django', 'MySQL']
   LLM 评分: 82/100 - 技能高度匹配，有相关项目经验
⏭️ [跳过 #3] LLM 评分 45/50: 岗位要求前端经验，简历以后端为主
```

## Test plan
- [x] `DRY_RUN=1 uv run main.py` 验证关键词提取和过滤日志输出正确
- [x] 验证不传 `resume_keywords` 时行为与原版一致
- [x] 验证 DeepSeek API 余额不足时 LLM 评分默认放行
- [x] 验证 `min_keyword_match` 和 `min_llm_score` 参数可配置

🤖 Generated with [Claude Code](https://claude.com/claude-code)