### PR TITLE
feat: 桌面 App (PyTauri + React) — Phase A-C，dev 模式完整可用

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,5 +48,9 @@ RESUME_PATH=
 # LETTER_MIN_LEN=30
 # LETTER_MAX_LEN=800
 
+# 职位匹配过滤的 LLM 评分阈值（0-100），低于该分的职位跳过不投。默认 50
+# Minimum LLM match score (0-100) for the job filter; lower-scored jobs are skipped. Default 50
+# BOSS_MIN_MATCH_SCORE=50
+
 # JSONL 审计日志路径，默认 ./logs/letters.jsonl
 # LETTER_LOG_PATH=./logs/letters.jsonl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,11 @@ jobs:
           uv run python -c "from website_oper.finding_jobs import open_browser_with_options, log_in, get_tab, send_chat_message, shutdown"
           uv run python -c "from website_oper.write_response import send_job_descriptions_to_chat, chat"
           uv run python -c "from scripts.dump_boss_page import PROBE_JS, TARGET_URL, main"
-          uv run python -c "from gui.events import ProgressEvent, ProgressSink, current_progress, emit"
-          uv run python -c "from gui.runner import start_run, stop_run, is_running, get_sink, get_task, reset"
-          uv run python -c "from gui.log_bridge import AsyncQueueHandler, install, uninstall"
+          uv run python -c "from gui.events import ProgressEvent, EventKind, emit, set_emit_callback"
+          uv run python -c "from gui.runner import start_run, stop_run, is_running, get_task, reset"
+          uv run python -c "from gui.log_bridge import CallbackHandler, install, uninstall"
+          uv run python -c "from gui.env_io import read_env, write_env, field_meta, KNOWN_KEYS"
+          uv run python -c "from gui.history import read_letters"
 
       - name: 跑 pytest
         run: uv run pytest tests/ -v --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,13 @@ jobs:
           uv run python -c "from models.llm import PROVIDERS, generate_letter, _build_client"
           uv run python -c "from models.openai_assistant import create_assistant, OPENAI_API_KEY"
           uv run python -c "from models.prompts import assistant_instructions"
-          uv run python -c "from website_oper.finding_jobs import open_browser_with_options, log_in, get_tab, send_chat_message"
+          uv run python -c "from models.job_matcher import should_apply, keyword_match, llm_match_score, extract_keywords_from_text, extract_resume_text"
+          uv run python -c "from website_oper.finding_jobs import open_browser_with_options, log_in, get_tab, send_chat_message, shutdown"
           uv run python -c "from website_oper.write_response import send_job_descriptions_to_chat, chat"
           uv run python -c "from scripts.dump_boss_page import PROBE_JS, TARGET_URL, main"
+          uv run python -c "from gui.events import ProgressEvent, ProgressSink, current_progress, emit"
+          uv run python -c "from gui.runner import start_run, stop_run, is_running, get_sink, get_task, reset"
+          uv run python -c "from gui.log_bridge import AsyncQueueHandler, install, uninstall"
 
       - name: 跑 pytest
         run: uv run pytest tests/ -v --tb=short

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,12 @@
 .claude/skills/**/workspace/
 .claude/skills/*-workspace/
 
+# Tauri 桌面 App 构建产物 + 前端依赖
+/tauri-ui/node_modules/
+/tauri-ui/dist/
+/boss_tauri/frontend/
+/boss_tauri/__pycache__/
+
+# 简历 PDF（CLAUDE.md 红线，不能进仓）
+/resume/*.pdf
+

--- a/boss_tauri/Tauri.toml
+++ b/boss_tauri/Tauri.toml
@@ -1,0 +1,18 @@
+"$schema" = "https://schema.tauri.app/config/2"
+productName = "BOSS Zhipin Helper"
+version = "0.3.0"
+identifier = "com.longsizhuo.boss-zhipin"
+
+[build]
+frontendDist = "./frontend"
+
+[app]
+withGlobalTauri = true
+
+[[app.windows]]
+title = "BOSS Zhipin Helper"
+label = "main"
+width = 1000
+height = 720
+minWidth = 600
+minHeight = 400

--- a/boss_tauri/__init__.py
+++ b/boss_tauri/__init__.py
@@ -1,0 +1,314 @@
+"""PyTauri 桌面 App 入口。
+
+跑：``uv sync --extra tauri && uv run python -m boss_tauri``
+
+跟 CLI（``main.py``）平行存在；CLI 模式完全不动。本模块对外暴露三件事：
+
+- ``commands``：PyTauri ``Commands`` 实例，注册了 ``start_run`` / ``stop_run`` /
+  ``is_running`` / ``detect_providers`` 这些前端能调的命令。
+- ``main()``：起 PyTauri app 的入口。
+- 各个 ``@commands.command()`` 函数本身——单测可以直接调（不通过 IPC）。
+
+业务代码（``website_oper`` / ``audit``）**完全不知道有 Tauri 这层**：
+- 进度事件通过 ``gui.events.set_emit_callback`` 注入到 PyTauri Channel
+- 日志通过 ``gui.log_bridge.install`` 注入到 PyTauri Channel
+- 主循环还是 ``website_oper.write_response.send_job_descriptions_to_chat``
+
+**关键约束**（见 project memory）：
+- `start_blocking_portal("asyncio")` —— 不能默认 trio/uvloop，否则 nodriver
+  重启 Chrome 会 timeout。
+- ``capabilities/default.toml`` 必须 grant ``pytauri:default``，否则前端的
+  ``pyInvoke`` 会被 Tauri ACL 拦。
+"""
+from os import environ
+from pathlib import Path
+
+# pytauri 多 example 共存时用，单 example 不需要——保留以匹配官方模板。
+environ.setdefault("_PYTAURI_DIST", "pytauri-wheel")
+
+import asyncio
+import functools
+import logging
+from typing import Optional
+
+from anyio.from_thread import start_blocking_portal
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+from pytauri import Commands
+from pytauri.ipc import Channel, JavaScriptChannelId
+from pytauri.webview import WebviewWindow
+from pytauri_wheel.lib import builder_factory, context_factory
+
+from gui import log_bridge, runner
+from gui.events import ProgressEvent
+
+SRC_TAURI_DIR = Path(__file__).parent.absolute()
+BOSS_DEV = environ.get("BOSS_TAURI_DEV") == "1"
+
+log = logging.getLogger(__name__)
+
+commands = Commands()
+
+
+class _CamelModel(BaseModel):
+    """前端 TS 用 camelCase，Python 用 snake_case。"""
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+
+class RunConfig(_CamelModel):
+    """``start_run`` 的参数。
+
+    字段对齐 ``main.py`` 走 CLI 时收集的东西。空字符串 / None 走跟 CLI
+    一样的默认（比如 label 空时用 BOSS 默认推荐 feed）。
+    """
+    usr_name: str
+    label: str = ""
+    provider: str  # "deepseek" / "chatgpt" / "claude"
+    dry_run: bool = False
+    resume_path: str = ""  # 空 → 用 RESUME_PATH env / 默认值
+
+
+class StartRunBody(_CamelModel):
+    config: RunConfig
+    progress_channel: JavaScriptChannelId[ProgressEvent]
+    log_channel: JavaScriptChannelId[str]
+
+
+@commands.command()
+async def detect_providers() -> dict[str, list[str]]:
+    """前端用来填 provider 下拉——返回当前 env 里配了哪些 API key。
+
+    复用 ``main.py:detect_providers``，避免 CLI 和 GUI 行为分叉。
+    """
+    # 延迟 import，避免本模块在 CLI 测试里被意外引入
+    import main  # noqa: WPS433
+
+    return {"providers": main.detect_providers()}
+
+
+@commands.command()
+async def is_running() -> dict[str, bool]:
+    """前端轮询用——返回当前 run 是否还活着。"""
+    return {"running": runner.is_running()}
+
+
+def _build_main_loop_factory(config: RunConfig):
+    """把 RunConfig + env var 折叠成一个无参的 coroutine 工厂。
+
+    工厂调用时（runner.start_run 内部）才真正 import 业务代码 + 构造
+    LLM client + 跑 vectorization。这一切都在主 portal loop 里跑，nodriver
+    要求的"同一 loop"约束满足。
+    """
+    async def factory():
+        # 延迟 import，让没装 ``tauri`` 可选依赖时 import boss_tauri 不立即炸。
+        from main import RECOMMEND_URL, PROVIDER_ENV_KEYS
+        from vectorization import embed_pdf
+        from website_oper.write_response import send_job_descriptions_to_chat
+        from models.job_matcher import extract_keywords_from_text, extract_resume_text
+
+        # 同步到 env，业务代码深处读 env 的地方（DRY_RUN / RESUME_PATH 等）也能感知
+        if config.dry_run:
+            environ["DRY_RUN"] = "1"
+        environ["BOSS_USR_NAME"] = config.usr_name
+        if config.resume_path:
+            environ["RESUME_PATH"] = config.resume_path
+        if config.label:
+            environ["BOSS_LABEL"] = config.label
+
+        provider = config.provider
+        if provider not in PROVIDER_ENV_KEYS:
+            raise ValueError(f"unknown provider: {provider!r}")
+
+        # 简历预处理（跟 CLI 入口顺序一致）
+        resume_path = environ.get("RESUME_PATH", "").strip() or "resume/my_cover.pdf"
+        resume_text = extract_resume_text(resume_path)
+        resume_keywords = extract_keywords_from_text(resume_text)
+        min_llm_score = int(environ.get("BOSS_MIN_MATCH_SCORE", "50"))
+
+        common_kwargs = dict(
+            usr_name=config.usr_name,
+            url=RECOMMEND_URL,
+            browser_type="chrome",
+            label=config.label,
+            dry_run=config.dry_run,
+            resume_keywords=resume_keywords,
+            resume_text=resume_text,
+            min_llm_score=min_llm_score,
+        )
+
+        if provider == "chatgpt":
+            # OpenAI 走 Assistants API，需要 client + assistant_id
+            from openai import OpenAI
+            from models.openai_assistant import OPENAI_API_KEY, create_assistant
+
+            chatgpt_model = environ.get("CHATGPT_MODEL", "").strip() or "gpt-4o"
+            openai_base_url = environ.get("OPENAI_BASE_URL", "").strip()
+            client_openai = OpenAI(
+                api_key=OPENAI_API_KEY,
+                base_url=openai_base_url or None,
+            )
+            assistant_id = create_assistant(
+                config.usr_name, chatgpt_model, client_openai, resume_path=resume_path
+            )
+            await send_job_descriptions_to_chat(
+                models="chatgpt",
+                client_openAI=client_openai,
+                assistant_id=assistant_id,
+                **common_kwargs,
+            )
+        else:
+            # deepseek / claude 走 RAG，需要 vectorstore
+            vectorstore = embed_pdf(resume_path, "./vectorstores")
+            await send_job_descriptions_to_chat(
+                models=provider,
+                vectorstore=vectorstore,
+                **common_kwargs,
+            )
+
+    return factory
+
+
+@commands.command()
+async def start_run(body: StartRunBody, webview_window: WebviewWindow) -> dict[str, str]:
+    """前端 ``pyInvoke('start_run', { config, progressChannel, logChannel })`` 调。
+
+    立刻返回 ``{status: "started"}``；进度通过 progress channel 推，日志通过
+    log channel 推，前端订阅那两个 channel 自己消费。
+
+    报错：
+    - already running → ``RuntimeError`` 由 PyTauri 自动序列化成前端 ``catch`` 能拿到的字符串
+    - bad provider → ``ValueError``
+    """
+    if runner.is_running():
+        raise RuntimeError("already running")
+
+    progress_channel = body.progress_channel.channel_on(webview_window.as_ref_webview())
+    log_channel = body.log_channel.channel_on(webview_window.as_ref_webview())
+
+    # 进度事件 → Channel
+    def on_event(ev: ProgressEvent) -> None:
+        try:
+            progress_channel.send_model(ev)
+        except Exception:
+            pass
+
+    # logging → Channel
+    log_handler = log_bridge.install(lambda msg: _safe_send(log_channel, msg))
+
+    factory = _build_main_loop_factory(body.config)
+
+    # 包一层：run 结束后卸 log handler
+    async def factory_with_cleanup():
+        try:
+            await factory()
+        finally:
+            log_bridge.uninstall(log_handler)
+
+    runner.start_run(factory_with_cleanup, on_event=on_event)
+    return {"status": "started"}
+
+
+def _safe_send(channel, msg: str) -> None:
+    try:
+        channel.send(msg)
+    except Exception:
+        pass
+
+
+@commands.command()
+async def stop_run() -> dict[str, str]:
+    """前端 stop 按钮调。idempotent——没在跑也不报错。"""
+    stopped = await runner.stop_run(timeout=30.0)
+    return {"status": "stopped" if stopped else "idle"}
+
+
+@commands.command()
+async def shutdown_browser() -> dict[str, str]:
+    """关 Chrome——给"完全重置"按钮用。stop_run 之后再调这个才能从头来。"""
+    from website_oper import finding_jobs
+    await finding_jobs.shutdown()
+    return {"status": "ok"}
+
+
+# ---------- Config 面板 ----------
+
+
+class EnvField(_CamelModel):
+    key: str
+    label: str
+    is_secret: bool
+    value: str
+
+
+@commands.command()
+async def get_env_fields() -> dict[str, list[EnvField]]:
+    """返回前端 Config 表单的所有字段 + 当前值。"""
+    from gui.env_io import field_meta, read_env
+
+    current = read_env()
+    fields = [
+        EnvField(
+            key=meta["key"],  # type: ignore[arg-type]
+            label=meta["label"],  # type: ignore[arg-type]
+            is_secret=bool(meta["isSecret"]),
+            value=current.get(meta["key"], ""),  # type: ignore[arg-type]
+        )
+        for meta in field_meta()
+    ]
+    return {"fields": fields}
+
+
+class WriteEnvBody(_CamelModel):
+    updates: dict[str, str]
+
+
+@commands.command()
+async def write_env_fields(body: WriteEnvBody) -> dict[str, str]:
+    """把表单的修改写回 .env。"""
+    from gui.env_io import write_env
+    write_env(body.updates)
+    return {"status": "saved"}
+
+
+# ---------- History 面板 ----------
+
+
+class _LimitBody(_CamelModel):
+    limit: int = 200
+
+
+@commands.command()
+async def get_letters(body: _LimitBody) -> dict[str, list[dict]]:
+    """读 ``logs/letters.jsonl`` 末尾 ``limit`` 条。"""
+    from gui.history import read_letters
+    return {"letters": read_letters(limit=body.limit)}
+
+
+@commands.command()
+async def get_telemetry_summary() -> dict[str, dict]:
+    """LLM 调用成本聚合。"""
+    from audit.telemetry import telemetry_summary
+    return {"summary": telemetry_summary(since_records=1000)}
+
+
+def main() -> int:
+    """启动 PyTauri app。"""
+    logging.basicConfig(
+        level=environ.get("LOGLEVEL", "INFO"),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    with start_blocking_portal("asyncio") as portal:
+        if BOSS_DEV:
+            tauri_config: Optional[dict] = {
+                "build": {"frontendDist": "http://localhost:1420"},
+            }
+        else:
+            tauri_config = None
+
+        app = builder_factory().build(
+            context=context_factory(SRC_TAURI_DIR, tauri_config=tauri_config),
+            invoke_handler=commands.generate_handler(portal),
+        )
+        return app.run_return()

--- a/boss_tauri/__main__.py
+++ b/boss_tauri/__main__.py
@@ -1,0 +1,6 @@
+"""``python -m boss_tauri`` 入口。"""
+import sys
+
+from boss_tauri import main
+
+sys.exit(main())

--- a/boss_tauri/capabilities/default.toml
+++ b/boss_tauri/capabilities/default.toml
@@ -1,0 +1,9 @@
+# 不传 pytauri:default Tauri ACL 会把所有 pyInvoke 拦掉。
+# 参考：project-pytauri-capabilities memory。
+identifier = "default"
+description = "Capability for the main window"
+windows = ["main"]
+permissions = [
+    "core:default",
+    "pytauri:default",
+]

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -6,6 +6,7 @@
 - [常见故障排查](troubleshooting.md) —— Chrome 闪退 / 反爬触发 / 卡登录页 等
 - [FAQ](faq.md) —— 跟使用 / 选 provider / 调 prompt 相关的常见问题
 - [Debugging Playbook](debugging-playbook.md) —— 难 bug 怎么查（agent 视角 + 指挥方视角）
+- [Postmortem 2026-05-13: CDP hang](postmortem-2026-05-13-cdp-hang.md) —— sync facade 跟 nodriver CDP 不兼容那次 bug 的完整复盘
 
 ## Architecture Decision Records (ADR)
 

--- a/docs/wiki/postmortem-2026-05-13-cdp-hang.md
+++ b/docs/wiki/postmortem-2026-05-13-cdp-hang.md
@@ -1,0 +1,353 @@
+# 复盘：nodriver CDP 在 sync facade 下随机 hang
+
+- **发生日期**：2026-05-13
+- **症状用户感知时长**：~36 小时（断断续续）
+- **实际排查耗时**：从锁定根因 → 修复 ~20 分钟
+- **走的弯路时长**：~1.5 小时（4-5 轮补丁式尝试，全部失败）
+- **影响**：`DRY_RUN=1 uv run main.py` 在第 1 个岗位处死循环超时，没法生成任何招呼语
+
+## TL;DR
+
+`website_oper/finding_jobs.py` 用 sync facade 模式（每个公开同步函数内部
+`uc.loop().run_until_complete(coro)`）跟 async 的 nodriver 做适配。**这个模式
+跟 nodriver 的 CDP 长连接根本不兼容**：事件循环每次 enter/exit，CDP websocket
+的内部状态机就错位一次，第二次 `tab.evaluate(...)` 永远等不到响应、永远卡住。
+
+修复 = **删掉 sync facade，全链路 async**，main.py 入口处 `uc.loop()
+.run_until_complete(send_job_descriptions_to_chat(...))` 一次性跑完所有
+浏览器 + LLM 调用。
+
+---
+
+## 1. 症状
+
+`DRY_RUN=1 uv run main.py` 输出：
+
+```
+01:09:32 页面已稳定，当前URL: https://www.zhipin.com/web/geek/jobs?ka=header-job-recommend
+01:09:32 再等 5s 让 Vue 把 JS 跑顺...
+01:09:37 检测到已登录
+01:09:37 [select_dropdown_option] label 为空，沿用当前推荐 feed
+01:09:37 === 第 1 轮: 处理 job_index=1 ===
+01:09:37 [get_job_description_by_index] index=1
+01:09:47 [WARNING] evaluate 超过 10s 没返回（JS: JSON.stringify(...)）
+01:09:47   点击 .job-card-box[1]: {}
+01:09:47 job_index=1 拿不到 JD（连续第 1 次）
+01:09:50 === 第 2 轮: 处理 job_index=2 ===
+01:09:50 [get_job_description_by_index] index=2
+01:10:00 [WARNING] evaluate 超过 10s 没返回...
+...
+```
+
+每一轮**都精确卡 10 秒到 timeout，无一例外**。点击没成功，JD 读不到，重试 5
+次后判断"feed 到底"提前退出。
+
+关键反直觉点：
+
+- xpath / CSS selector **都验证过有效**（dump 出来的 HTML 用 lxml 跑 xpath 命中 15 个 `.job-card-box`）
+- `tab.evaluate("1+1")` 在 dump 脚本里**秒返回**
+- 同样的代码、同样的 profile，**只有主流程会卡，独立 probe 不会卡**
+
+---
+
+## 2. 错误假设的弯路（4 轮）
+
+### 弯路 1：以为是 BOSS 改了 DOM
+
+第一直觉：BOSS 升级前端，老 xpath 失效。
+
+- 写了 `scripts/dump_boss_page.py` 抓 HTML + 截图 + 候选选择器探测
+- 用 grep / lxml 在 HTML 里翻新 class 名 → 找到 `.job-card-box`、`.job-detail-body`
+- 改 `finding_jobs.py` 用新选择器 → **跑还是 timeout**
+
+**为什么没修好**：新 xpath 是对的，问题不在 xpath 本身。但 timeout 让人继续往
+"选择器还是不对"方向猜。
+
+### 弯路 2：以为是 nodriver `tab.xpath()` 的 timeout 不可靠
+
+之前确实见过 `tab.select(timeout=0)` hang 的现象，所以怀疑 `tab.xpath` 也有同
+样毛病。
+
+- 把 `_get_job_description_by_index_impl` 整段重写，从 `tab.xpath()` 换到
+  `tab.evaluate(JS)` —— 在浏览器内部直接 `document.querySelectorAll(...).click()`
+- 写得很扎实：`asyncio.wait_for` 兜底超时、JSON 解析容错、`_js_click_at_index`
+  和 `_js_wait_text` 两个 helper、JS 内层 try/catch 包错误返回 `{ok:false, error:...}`
+- 跑 → **同样 10s timeout**
+
+**为什么没修好**：换 API 不能解决"channel 死了"的问题。`tab.xpath` 跟
+`tab.evaluate` 走同一个 websocket。
+
+### 弯路 3：以为是 Vue 还没渲染完
+
+dump 脚本 `await asyncio.sleep(8)` 后跑得稳，主流程只 `_wait_url_stable(2.0)`
+就开始抓 → 觉得是给 Vue 的时间不够。
+
+- `_open_browser_impl` 末尾再加 `await asyncio.sleep(5)`
+- 重跑 → **同样 10s timeout**
+
+**为什么没修好**：sleep 期间事件循环只在那一次 `_run` 里活着，sleep 结束后
+`_open_browser_impl` 返回，事件循环 exit。下次 `get_job_description_by_index`
+进入新的 `_run`，CDP 还是半死状态。**sleep 治不了"事件循环停顿"。**
+
+### 弯路 4：用 user 当测试床
+
+每次改一处，让 user `git pull` + `DRY_RUN=1 uv run main.py`，等 30s+ 看日志。
+跑 5 轮就是 ~3 分钟（中间还要 user 操作）。
+
+**为什么慢**：feedback loop 太长。一个改动验证一次假设要 user 配合，每次代价
+都很高。**应该写 probe 自己跑**。
+
+---
+
+## 3. 找到根因（第 5 轮）
+
+User 直接说**"你直接写一个 python 脚本抓取不就行了？一定要写到主链路里让我去
+测试"**。
+
+写了 `scripts/probe_click_card.py`：复用 `chrome_profile/` 登录态，分 5 个阶段
+独立测试 `tab.evaluate` 各种打法（1+1 → querySelector → IIFE → click → 等 JD）。
+
+跑了一次，**5 个阶段全部秒过**：
+
+```
+[阶段 1: 1+1]                    ✓ 0.01s | type=int | result=2
+[阶段 2: querySelectorAll]        ✓ 0.00s | type=int | result=15
+[阶段 3: 复杂 IIFE 查询]          ✓ 0.00s | type=str | result='{"url":...,"cards":15,...}'
+[阶段 4: 点击 .job-card-box[0]]   ✓ 0.01s | type=str | result='{"ok":true,"total":15}'
+[阶段 5: 点击后读 JD]             ✓ 0.00s | type=str | result='{"cards":15,"detail_text_len":1224,...}'
+```
+
+**问题不在 evaluate**。
+
+然后用 Bash 直接复现主流程：`uv run main.py` —— **同样的 evaluate 调用、同样的页面、同样的 nodriver**，全部 10s timeout。
+
+唯一差异：**probe 用一个 `run_until_complete(main())` 全程跑完；主流程跑三个 `_run(coro)`**。
+
+根因锁定。
+
+---
+
+## 4. 根因解释
+
+nodriver 跟 Chrome 的通信走 **CDP (Chrome DevTools Protocol) over websocket**：
+
+```
+你的 Python 代码
+    │
+    ▼ await tab.evaluate("...")
+nodriver 发送 CDP 请求 {"id": 42, "method": "Runtime.evaluate", ...}
+    │
+    ▼ over websocket
+Chrome 处理 → 返回 {"id": 42, "result": ...}
+    │
+    ▼ websocket 收到响应
+nodriver 的 background reader task 把响应跟请求 id 配对
+    │
+    ▼ 唤醒等待 id=42 的 Future
+你的 await 拿到结果返回
+```
+
+关键：**那个 background reader task 是 asyncio.Task，只在事件循环运行时才被调度**。
+
+旧 sync facade 长这样：
+
+```python
+def open_browser_with_options(url, browser):
+    return uc.loop().run_until_complete(_open_browser_impl(url))
+    # ^^ 事件循环进入、跑到 _impl 返回、退出
+
+def log_in():
+    return uc.loop().run_until_complete(_log_in_impl())
+    # ^^ 事件循环再次进入、退出
+
+def get_job_description_by_index(index):
+    return uc.loop().run_until_complete(_get_job_description_by_index_impl(index))
+    # ^^ 第三次进入、卡死
+```
+
+**两次 `run_until_complete` 之间，事件循环停止运转**。
+
+这段时间发生什么：
+
+- websocket 上 Chrome 发的消息**继续到达**（OS-level 缓冲）
+- nodriver reader task **没被调度**（loop 没在跑）
+- 当下一次 `run_until_complete` 进来时，reader task 醒过来开始处理
+- **但消息处理顺序乱了**：reader 期待响应 sequence 跟当前发请求的 sequence 已经对不上
+- 状态机错位，下一次 `tab.evaluate` 发出的请求**永远等不到匹配的 response**
+- 我们的 `asyncio.wait_for(timeout=10)` 强行超时，TimeoutError 上报
+
+**类比**：CDP 是一通电话，你和 Chrome 一直在通话。sync facade 相当于
+**每发一句话就挂机，下次再拨**。Chrome 那边以为通话已结束、新的拨号信号乱了，
+你听到的就是无尽嘟嘟声（timeout）。
+
+---
+
+## 5. 修复
+
+把整段流程改成**一条 async 调用链，只 `run_until_complete` 一次**。
+
+### 5.1 `website_oper/finding_jobs.py`
+
+删 `_run` 和所有 sync wrapper。公开函数全部 `async def`：
+
+```python
+# 改前
+def open_browser_with_options(url, browser):
+    if browser != "chrome":
+        raise NotImplementedError(...)
+    _run(_open_browser_impl(url))
+
+# 改后
+async def open_browser_with_options(url: str, browser: str) -> None:
+    if browser != "chrome":
+        raise NotImplementedError(...)
+    # 直接是之前 _impl 的内容
+    ...
+```
+
+涉及函数：`open_browser_with_options`、`log_in`、`select_dropdown_option`、
+`get_job_description_by_index`、`get_text_by_css`、`click_by_xpath`、
+`wait_for_css`、`send_chat_message`、`navigate_back`。
+
+### 5.2 `website_oper/write_response.py`
+
+`send_job_descriptions_to_chat` 改 `async def`，调用方加 `await`，`time.sleep`
+→ `await asyncio.sleep`：
+
+```python
+async def send_job_descriptions_to_chat(...) -> None:
+    await finding_jobs.open_browser_with_options(url, browser_type)
+    await finding_jobs.log_in()
+    await finding_jobs.select_dropdown_option(label)
+
+    while True:
+        job_description = await finding_jobs.get_job_description_by_index(job_index)
+        if job_description:
+            # LLM 调用是同步阻塞的 HTTP 请求，扔到 thread pool 跑
+            # 避免阻塞事件循环 → 卡死 nodriver CDP heartbeat
+            response = await asyncio.to_thread(
+                generate_letter,
+                usr_name, vectorstore, job_description, model=models,
+            )
+            ...
+        await asyncio.sleep(3)
+        job_index += 1
+```
+
+**关键细节**：LLM 调用（`generate_letter` / `chat`）是同步阻塞的，直接 `await`
+不能用。包 `asyncio.to_thread(...)` 扔到线程池里跑 —— **不是为了并发，是为了
+不阻塞主事件循环**，让 nodriver reader task 在 LLM 调用的几秒里继续工作。如果
+不这么做，LLM 调用的 3-5 秒里事件循环阻塞，CDP 又死了。
+
+### 5.3 `main.py`
+
+三处 `send_job_descriptions_to_chat(...)` 包成
+`uc.loop().run_until_complete(...)`：
+
+```python
+import nodriver as uc
+...
+if provider == "deepseek":
+    vectorstore = embed_pdf(resume_path, "./vectorstores")
+    uc.loop().run_until_complete(send_job_descriptions_to_chat(
+        usr_name, url, browser_type, label, "deepseek",
+        vectorstore=vectorstore, dry_run=dry_run,
+    ))
+elif provider == "chatgpt": ...
+elif provider == "claude": ...
+```
+
+**整段必须一个 `run_until_complete` 跑完**。在这里面，浏览器操作、LLM 调用、
+sleep、日志写入全部按 async 顺序执行；事件循环不再停顿。
+
+---
+
+## 6. 验证
+
+重跑 `DRY_RUN=1 uv run main.py`，**75 秒内连刷 7 个岗位**：
+
+```
+01:25:21 [get_job_description_by_index] index=1
+01:25:21   点击 .job-card-box[1]: {'ok': True, 'total': 15}   ← 0 秒！
+01:25:21   JD 长度 2346 字符
+01:25:21 chat 按钮文字: '立即沟通'
+01:25:35 [DRY-RUN] 招呼语 (255 字符) 不发送
+01:25:38 === 第 2 轮: 处理 job_index=2 ===
+01:25:38   点击 .job-card-box[2]: {'ok': True, 'total': 15}   ← 0 秒
+01:25:39   JD 长度 1646 字符
+01:25:43 [DRY-RUN] 招呼语 (371 字符) 不发送
+... 一直刷到第 7 轮，全部正常
+```
+
+每轮 ~8 秒（含 DeepSeek API 调用），相比修复前每轮 10 秒纯超时 + 0 输出，**整条
+链路从死到活**。59 个 pytest 单测全过（纯逻辑测试不受 async 改动影响）。
+
+---
+
+## 7. 为什么之前的尝试都没用
+
+| 尝试 | 期望解决 | 实际结果 | 为什么没用 |
+|---|---|---|---|
+| 改 xpath 用新 class | DOM 已变 | 还是 timeout | 选择器对的，根因不在 selector |
+| 换 `tab.evaluate(JS)` | `tab.xpath()` 不可靠 | 一样 timeout | 同一 websocket，channel 死了换 API 没用 |
+| `try/catch` 包 JS | JS 抛异常被吞 | 一样 timeout | JS 根本没执行（response 没回） |
+| 加 5s 额外 sleep | Vue 还没 ready | 一样 timeout | sleep 在 `_run` 里、出 `_run` 后 channel 还是死 |
+| 加大 timeout 5→10s | 等再久点 | 还是 timeout | response 永远不来，等到天荒地老也没用 |
+
+**所有补丁都在"治 evaluate 调用本身"，但 bug 在"调用之间的事件循环管理"。**
+治错了层。
+
+---
+
+## 8. 经验教训
+
+### 8.1 对项目的影响
+
+`docs/wiki/adr/001-nodriver-over-selenium.md` 当时说"sync facade + async impl"
+是合理设计。**这次复盘推翻了那个结论**：sync facade over nodriver async API 是
+反模式，不能用。下次升级 ADR-001 时要补这一节。
+
+类似的 async-only 库还有 [Playwright](https://playwright.dev/python/) —— 它的
+`playwright-python` 提供 sync API 但**内部用一个常驻线程跑 event loop**，不是
+裸 `run_until_complete` facade 模式。如果项目以后要换 Playwright，参考它的实现
+方式比手糊 sync facade 安全。
+
+### 8.2 通用调试原则
+
+详见 [debugging-playbook.md](debugging-playbook.md)，本次踩中的所有反模式都列
+了。简短回顾：
+
+1. **同一个 bug 第 2 次补丁失败 → 退回去重新形成假设**。不要继续往下补，先想
+   清楚根因是什么。
+2. **写 probe 比改主流程快 10 倍**。本次 1.5 小时弯路 vs 20 分钟根因定位，差距
+   就在这。
+3. **Agent 在用户本地，自己跑别让用户当测试床**。除非操作本身需要用户介入
+   （扫码、下卡），否则 agent 应该自己 `uv run ...` 直接看结果。
+4. **bisect 思维**：找到"已知能跑的"（probe）和"已知不能跑的"（main），逐项
+   对比差异。本次差异是"事件循环进入次数"，这就是根因候选。
+
+### 8.3 仪式 vs 实质
+
+之前**对 ADR-001 / nodriver 选型有充分讨论**（沟通几小时），但**没人想过 sync
+facade 的可行性边界**。这个 bug 暴露了一个盲点：**项目结构决策（async vs
+sync）跟库的实现细节（CDP 是 stateful 长连接）有耦合，不能纯凭 API 表面签名
+决定**。
+
+下次引入 async 库时增加一项 check：
+
+> 这个库的 async 是"语法糖"（每次调用独立），还是"持续状态"（依赖事件循环
+> 持续运行）？后者**不能**用 sync facade，必须全链路 async。
+
+判断方法：看库内部是否有 `asyncio.create_task` 起 background reader / writer /
+heartbeat task。nodriver 有（CDP reader）、Playwright 有（CDP reader）、
+`httpx.AsyncClient` 没有（每次请求独立）。
+
+---
+
+## 9. 相关文件
+
+- 修复 commit（待 commit）：`website_oper/finding_jobs.py` + `website_oper/write_response.py` + `main.py`
+- 帮我找到根因的 probe：[`scripts/probe_click_card.py`](../../scripts/probe_click_card.py)
+- HTML dump 工具：[`scripts/dump_boss_page.py`](../../scripts/dump_boss_page.py)
+- 通用调试方法论：[`debugging-playbook.md`](debugging-playbook.md)
+- 浏览器选型 ADR（待补 sync-facade 反例）：[`adr/001-nodriver-over-selenium.md`](adr/001-nodriver-over-selenium.md)

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,0 +1,16 @@
+"""本地 Web GUI（NiceGUI），跟 CLI ``main.py`` 平行的入口。
+
+跑：``uv run boss-gui`` 或 ``uv run python -m gui``。
+
+设计：
+- 复用 ``main.py`` 的 provider 检测、``website_oper`` 的所有 async helper、
+  ``audit`` 的招呼语校验。
+- 通过 ``gui.events.current_progress`` ContextVar 把进度事件注入业务代码，
+  CLI 模式 sink=None 时业务代码行为完全不变。
+- ``gui.log_bridge`` 把 root logger 的输出桥接到 asyncio.Queue，给 UI 的
+  ``ui.log`` 控件订阅。
+
+关键约束（见 ``project-nicegui-uvloop-incompat`` memory）：
+- ``ui.run()`` 必须传 ``loop="asyncio"``，否则 nodriver 的 Chrome 重启会 timeout。
+- ``ui.run()`` 必须 ``reload=False``，否则 Chrome 子进程会变孤儿。
+"""

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,16 +1,26 @@
-"""本地 Web GUI（NiceGUI），跟 CLI ``main.py`` 平行的入口。
+"""GUI 层共享工具——给 ``boss_tauri`` (PyTauri 桌面 App) 用，**不依赖** PyTauri 本身。
 
-跑：``uv run boss-gui`` 或 ``uv run python -m gui``。
+CLI ``main.py`` 不调本包；CLI 行为不受 ``gui/`` 任何代码影响。
 
-设计：
-- 复用 ``main.py`` 的 provider 检测、``website_oper`` 的所有 async helper、
-  ``audit`` 的招呼语校验。
-- 通过 ``gui.events.current_progress`` ContextVar 把进度事件注入业务代码，
-  CLI 模式 sink=None 时业务代码行为完全不变。
-- ``gui.log_bridge`` 把 root logger 的输出桥接到 asyncio.Queue，给 UI 的
-  ``ui.log`` 控件订阅。
+模块清单：
+
+- ``events`` —— ``ProgressEvent`` (Pydantic) + ``emit(kind, **payload)``。业务代码
+  ``website_oper.write_response`` 在关键节点调 ``emit()``；callback=None 时 no-op，
+  CLI 模式行为零变化。GUI 入口用 ``set_emit_callback`` 注册一个 PyTauri Channel
+  send 函数即可订阅。
+- ``runner`` —— ``start_run(coro_factory, on_event)`` / ``stop_run()`` /
+  ``is_running()``，把主循环包成可取消 asyncio Task，task 内 emit
+  ``loop_ended(reason)``。
+- ``log_bridge`` —— ``CallbackHandler`` 把 ``logging.LogRecord`` 喂给 callback。
+- ``env_io`` —— 读/写 ``.env`` 表单字段（GUI Config tab 用）。
+- ``history`` —— 读 ``logs/letters.jsonl`` 末尾 N 条（GUI History tab 用）。
+
+桌面 App 入口在 ``boss_tauri/__init__.py``：``uv sync --extra tauri`` 后
+``uv run python -m boss_tauri``。
 
 关键约束（见 ``project-nicegui-uvloop-incompat`` memory）：
-- ``ui.run()`` 必须传 ``loop="asyncio"``，否则 nodriver 的 Chrome 重启会 timeout。
-- ``ui.run()`` 必须 ``reload=False``，否则 Chrome 子进程会变孤儿。
+- PyTauri 起 app 时必须 ``start_blocking_portal("asyncio")``，不能 trio /
+  uvloop——uvloop 跟 nodriver 的 Chrome stop+restart 不兼容。
+- ``boss_tauri/capabilities/default.toml`` 必须 grant ``pytauri:default``，
+  否则前端 ``pyInvoke`` 全部被 Tauri ACL 拦。
 """

--- a/gui/env_io.py
+++ b/gui/env_io.py
@@ -1,0 +1,78 @@
+"""GUI 配置面板用——读/写 ``.env`` 表单字段。
+
+只动 ``.env``，**不动 ``os.environ``**——避免 GUI 修改的字段污染同进程里
+其他模块的读 env 操作（特别是 LLM client 在 import 时读 API key）。GUI
+保存后用户需要重启 app 或重新 start_run 让新值生效。
+
+API key 字段在前端 mask（password input），后端不主动 mask——前端拿到
+真实值后用户改的时候不至于看到 ``***``。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from dotenv import dotenv_values, set_key, unset_key
+
+# 暴露给前端的配置字段。每一项映射 ``.env`` 里一个 key。
+# 顺序决定前端表单顺序。
+KNOWN_KEYS: list[tuple[str, str, bool]] = [
+    # (env key, 字段说明, is_secret)
+    ("DEEPSEEK_API_KEY", "DeepSeek API key", True),
+    ("OPENAI_API_KEY", "OpenAI API key", True),
+    ("ANTHROPIC_API_KEY", "Anthropic (Claude) API key", True),
+    ("BOSS_USR_NAME", "你的名字（招呼语署名）", False),
+    ("BOSS_LABEL", "求职 tag（空走 BOSS 推荐 feed）", False),
+    ("RESUME_PATH", "简历 PDF 路径（默认 ./resume/my_cover.pdf）", False),
+    ("CHATGPT_MODEL", "OpenAI 模型（默认 gpt-4o）", False),
+    ("OPENAI_BASE_URL", "OpenAI 代理 URL（可选）", False),
+    ("BOSS_CHROME_PROFILE", "Chrome profile 目录（默认 ./chrome_profile）", False),
+    ("BOSS_MIN_MATCH_SCORE", "LLM 匹配分阈值（默认 50）", False),
+    ("LOGLEVEL", "日志级别（默认 INFO）", False),
+]
+
+
+def _env_path() -> Path:
+    return Path(".env")
+
+
+def read_env() -> dict[str, str]:
+    """返回 .env 里已经设了的 key → value。
+
+    缺失文件返回空 dict。Comment 行 / 解析错误自动跳过。**只返回 KNOWN_KEYS
+    里的字段**——其他字段（用户自己加的）不在前端表单里，也不让前端不小心
+    覆盖掉。
+    """
+    path = _env_path()
+    if not path.is_file():
+        return {}
+    raw = dotenv_values(path)
+    return {k: v for k, v in raw.items() if v is not None and k in {kk for kk, _, _ in KNOWN_KEYS}}
+
+
+def write_env(updates: dict[str, str]) -> None:
+    """把表单提交的 key/value 写回 .env。
+
+    - 空字符串 → ``unset_key`` 把那一行删掉（区别于"留空但保留 key"）
+    - 不存在的 key 自动 append
+    - 跟 read_env 一样**只允许 KNOWN_KEYS 里的字段**，防注入
+    """
+    path = _env_path()
+    path.touch(exist_ok=True)
+    allowed = {k for k, _, _ in KNOWN_KEYS}
+    for k, v in updates.items():
+        if k not in allowed:
+            continue
+        if v == "":
+            try:
+                unset_key(str(path), k)
+            except Exception:
+                pass
+        else:
+            set_key(str(path), k, v, quote_mode="never")
+
+
+def field_meta() -> list[dict[str, str | bool]]:
+    """给前端的 fields metadata（key / label / is_secret）。"""
+    return [{"key": k, "label": label, "isSecret": is_secret}
+            for k, label, is_secret in KNOWN_KEYS]

--- a/gui/env_io.py
+++ b/gui/env_io.py
@@ -10,7 +10,6 @@ API key 字段在前端 mask（password input），后端不主动 mask——前
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable
 
 from dotenv import dotenv_values, set_key, unset_key
 
@@ -36,6 +35,9 @@ def _env_path() -> Path:
     return Path(".env")
 
 
+_ALLOWED_KEYS: frozenset[str] = frozenset(k for k, _, _ in KNOWN_KEYS)
+
+
 def read_env() -> dict[str, str]:
     """返回 .env 里已经设了的 key → value。
 
@@ -47,7 +49,7 @@ def read_env() -> dict[str, str]:
     if not path.is_file():
         return {}
     raw = dotenv_values(path)
-    return {k: v for k, v in raw.items() if v is not None and k in {kk for kk, _, _ in KNOWN_KEYS}}
+    return {k: v for k, v in raw.items() if v is not None and k in _ALLOWED_KEYS}
 
 
 def write_env(updates: dict[str, str]) -> None:
@@ -59,9 +61,8 @@ def write_env(updates: dict[str, str]) -> None:
     """
     path = _env_path()
     path.touch(exist_ok=True)
-    allowed = {k for k, _, _ in KNOWN_KEYS}
     for k, v in updates.items():
-        if k not in allowed:
+        if k not in _ALLOWED_KEYS:
             continue
         if v == "":
             try:

--- a/gui/events.py
+++ b/gui/events.py
@@ -1,0 +1,65 @@
+"""业务代码 → GUI 的事件总线。
+
+业务代码（``website_oper/write_response.py`` 等）在关键节点调 ``emit(kind, **payload)``，
+由当前注册的 callback 把事件路由到 GUI 框架（PyTauri Channel / 测试断言 / log）。
+
+设计要点：
+- **没装 pytauri 也能 import**。本模块只依赖 stdlib + pydantic。CLI 模式（main.py）
+  不调 ``set_emit_callback``，emit() 自动是 no-op，业务代码行为零变化。
+- **module-global callback，不用 ContextVar**。只允许同时跑一个 run（``gui.runner``
+  的契约），所以不需要 ContextVar 的 task-local 隔离。简单一个全局变量够。
+- ``ProgressEvent`` 是 Pydantic v2 model——PyTauri Channel 自动认 BaseModel
+  做序列化，前端 TypeScript 端有相应类型。
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Literal, Optional
+
+from pydantic import BaseModel
+
+EventKind = Literal[
+    "browser_started",   # Chrome 起来了
+    "login_ok",          # 登录态确认
+    "job_found",         # 抓到一个 JD，payload: {index, jd_preview}
+    "job_skipped",       # 跳过当前岗位，payload: {index, reason, detail}
+    "letter_sent",       # 招呼语处理完成，payload: {index, status: "sent"|"dry_run"|"blocked"}
+    "feed_exhausted",    # 推荐 feed 跑到底（连续 N 次拿不到 JD），payload: {total}
+    "loop_ended",        # runner 包的整段结束，payload: {reason: "completed"|"cancelled"|"error"}
+    "error",             # 任何阶段抛了未捕获异常，payload: {stage, message}
+]
+
+
+class ProgressEvent(BaseModel):
+    """业务代码发给 GUI 的结构化事件。
+
+    payload 是个 dict 而非每个 kind 一个子类，因为：
+    - 事件类型少（8 个）
+    - 前端用 switch/match 一处分发，子类反而要类型守卫
+    - 加字段不破坏老代码
+    """
+
+    kind: EventKind
+    payload: dict[str, Any] = {}
+
+
+_emit_callback: Optional[Callable[[ProgressEvent], None]] = None
+
+
+def set_emit_callback(cb: Optional[Callable[[ProgressEvent], None]]) -> None:
+    """注册 callback。GUI 模式在 start_run 之前 set，结束后 clear。"""
+    global _emit_callback
+    _emit_callback = cb
+
+
+def emit(kind: EventKind, **payload: Any) -> None:
+    """业务代码的 emit 助手。callback=None 时（CLI 模式）静默 no-op。
+
+    callback 抛异常不会传播——业务代码不应该因为 GUI 端的 bug 挂掉。
+    """
+    cb = _emit_callback
+    if cb is None:
+        return
+    try:
+        cb(ProgressEvent(kind=kind, payload=payload))
+    except Exception:
+        pass

--- a/gui/history.py
+++ b/gui/history.py
@@ -1,0 +1,42 @@
+"""GUI 历史面板用——读 ``logs/letters.jsonl``。
+
+``audit.__init__`` 负责写，本模块负责读。分开是因为：
+- ``audit`` 是 CLI 也用的业务模块，不应该 import 任何"列表读取/分页"逻辑
+- 测试 ``audit.log_attempt`` 不需要测 read
+- 未来历史面板想加过滤/分页/全文搜索，集中在这里
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def _letters_path() -> Path:
+    return Path(os.getenv("LETTER_LOG_PATH", "./logs/letters.jsonl"))
+
+
+def read_letters(limit: int = 200) -> list[dict[str, Any]]:
+    """读 letters.jsonl 最末尾 ``limit`` 条，最新的在 list 末尾。
+
+    文件不存在 / 解析失败的行被跳过——前端面板不会因为一条坏数据整个崩。
+    """
+    path = _letters_path()
+    if not path.is_file():
+        return []
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError:
+        return []
+    out: list[dict[str, Any]] = []
+    for line in lines[-limit:]:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out

--- a/gui/log_bridge.py
+++ b/gui/log_bridge.py
@@ -1,0 +1,67 @@
+"""把 root logger 的输出路由到注册的 callback（PyTauri Channel / 测试断言）。
+
+logger 是被业务代码的同步上下文用，所以 handler 的 ``emit`` 必须同步。
+caller 在 callback 里做异步推送（如 ``channel.send(msg)``）即可——PyTauri
+Channel 的 send 本身是 sync 的，所以没问题。
+
+**仅 GUI 进程安装这个 handler**。CLI 模式（``main.py``）不调本模块，
+logger 行为完全不变。
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+
+class CallbackHandler(logging.Handler):
+    """把格式化后的 LogRecord 字符串扔给 callback。
+
+    callback 抛异常不传播给业务代码——GUI 侧的 bug 不应让 logger 挂。
+    """
+
+    def __init__(self, callback: Callable[[str], None]) -> None:
+        super().__init__()
+        self.callback = callback
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            msg = self.format(record)
+        except Exception:
+            self.handleError(record)
+            return
+        try:
+            self.callback(msg)
+        except Exception:
+            pass
+
+
+_installed_handler: Optional[CallbackHandler] = None
+
+
+def install(callback: Callable[[str], None], level: int = logging.INFO) -> CallbackHandler:
+    """挂一个桥接 handler 到 root logger。重复调会先卸掉旧的。"""
+    global _installed_handler
+    if _installed_handler is not None:
+        uninstall(_installed_handler)
+    handler = CallbackHandler(callback)
+    handler.setLevel(level)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%H:%M:%S",
+        )
+    )
+    logging.getLogger().addHandler(handler)
+    _installed_handler = handler
+    return handler
+
+
+def uninstall(handler: CallbackHandler) -> None:
+    """从 root logger 移除指定 handler。idempotent。"""
+    global _installed_handler
+    try:
+        logging.getLogger().removeHandler(handler)
+    except Exception:
+        pass
+    if _installed_handler is handler:
+        _installed_handler = None

--- a/gui/runner.py
+++ b/gui/runner.py
@@ -1,0 +1,106 @@
+"""把主循环包成一个可取消的 asyncio Task，并把进度事件路由到注册的 callback。
+
+为什么需要这一层：
+- ``website_oper.write_response.send_job_descriptions_to_chat`` 是 async 函数，
+  GUI 入口必须用 ``asyncio.create_task(...)`` 挂到当前 running loop。
+- "停止"按钮要能取消，所以需要拿到 Task 引用调 ``task.cancel()``。
+- 取消时要 emit ``loop_ended(reason="cancelled")`` 让 UI 显示干净的"已停止"。
+
+设计上**不直接 import** ``send_job_descriptions_to_chat``——接受 ``coro_factory``
+（无参 → coroutine 的工厂）。这样：
+- 测试可以传 ``lambda: asyncio.sleep(60)`` 不依赖 nodriver
+- PyTauri command 在 ``src-tauri/python/`` 里 partial 出 factory，把表单参数绑进去
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable, Callable, Optional
+
+from gui.events import ProgressEvent, emit, set_emit_callback
+
+log = logging.getLogger(__name__)
+
+_task: Optional[asyncio.Task] = None
+
+
+def is_running() -> bool:
+    return _task is not None and not _task.done()
+
+
+def get_task() -> Optional[asyncio.Task]:
+    """主要给测试用——生产代码应该用 ``is_running()``。"""
+    return _task
+
+
+async def _wrap(coro: Awaitable[None]) -> None:
+    """业务 coroutine 外壳：catch 异常 + emit loop_ended + 清 callback。"""
+    try:
+        try:
+            await coro
+            emit("loop_ended", reason="completed")
+        except asyncio.CancelledError:
+            emit("loop_ended", reason="cancelled")
+            raise  # 必须继续传，否则 Task 不会真正 cancelled
+        except Exception as e:
+            log.exception("runner: main loop crashed")
+            emit("error", stage="main_loop", message=f"{type(e).__name__}: {e}")
+            emit("loop_ended", reason="error")
+    finally:
+        # 不管是自然结束、cancel、还是异常，都要清 callback——避免下一次 start_run
+        # 之前的旧 callback 还在收事件。
+        set_emit_callback(None)
+
+
+def start_run(
+    coro_factory: Callable[[], Awaitable[None]],
+    on_event: Optional[Callable[[ProgressEvent], None]] = None,
+) -> asyncio.Task:
+    """启动一次新的运行。
+
+    ``on_event`` 是事件 sink。GUI 模式传 PyTauri Channel 的 send；测试可以
+    收集到 list 里断言。None 时业务代码 ``emit()`` 是 no-op。
+
+    已有运行时抛 ``RuntimeError``，避免双开覆盖。
+    """
+    global _task
+    if is_running():
+        raise RuntimeError("a run is already in progress")
+    set_emit_callback(on_event)
+    _task = asyncio.create_task(_wrap(coro_factory()))
+    return _task
+
+
+async def stop_run(timeout: float = 30.0) -> bool:
+    """取消当前 task 并等它退出。返回 False 表示当时没在跑（idempotent）。
+
+    timeout 内没退出返回 True，但 task 可能仍在跑——通常因为底层 LLM 同步
+    HTTP 请求 in flight，没办法被 cancel 立刻打断。
+
+    本函数**不**关 Chrome。Chrome 在 GUI 进程生命周期内保持启动，下一次
+    ``start_run`` 直接复用 cookie。需要彻底关 Chrome 调
+    ``website_oper.finding_jobs.shutdown()``。
+    """
+    global _task
+    if not is_running():
+        return False
+    assert _task is not None
+    _task.cancel()
+    try:
+        await asyncio.wait_for(_task, timeout=timeout)
+    except asyncio.CancelledError:
+        pass
+    except asyncio.TimeoutError:
+        log.warning("runner: task didn't exit within %.1fs of cancel", timeout)
+    except Exception:
+        log.exception("runner: task raised during shutdown")
+    finally:
+        set_emit_callback(None)
+    return True
+
+
+def reset() -> None:
+    """主要给测试用——清掉模块级 _task 引用 + emit callback。"""
+    global _task
+    _task = None
+    set_emit_callback(None)

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ import nodriver as uc
 from dotenv import load_dotenv
 from openai import OpenAI
 
-from models.job_matcher import extract_keywords_from_resume, extract_resume_text
+from models.job_matcher import extract_keywords_from_text, extract_resume_text
 from models.openai_assistant import OPENAI_API_KEY, create_assistant
 from vectorization import embed_pdf
 from website_oper.write_response import send_job_descriptions_to_chat
@@ -41,6 +41,9 @@ PROVIDER_ENV_KEYS: dict[str, str] = {
     "chatgpt": "OPENAI_API_KEY",
     "claude": "ANTHROPIC_API_KEY",
 }
+
+# BOSS 推荐 feed 入口。CLI 和 GUI 都从这里进。
+RECOMMEND_URL = "https://www.zhipin.com/web/geek/job-recommend?ka=header-job-recommend"
 
 PROVIDER_SIGNUP: dict[str, str] = {
     "deepseek": "https://platform.deepseek.com/api_keys",
@@ -114,13 +117,15 @@ if __name__ == "__main__":
     else:
         print("没设 BOSS_LABEL，用 BOSS 默认推荐 feed")
 
-    url = "https://www.zhipin.com/web/geek/job-recommend?ka=header-job-recommend"
+    url = RECOMMEND_URL
     browser_type = "chrome"
 
     # 从简历自动提取关键词和全文（用于职位匹配过滤）
-    resume_keywords = extract_keywords_from_resume(resume_path)
     resume_text = extract_resume_text(resume_path)
+    resume_keywords = extract_keywords_from_text(resume_text)
     print(f"📋 从简历中提取到 {len(resume_keywords)} 个关键词: {resume_keywords}")
+    # LLM 匹配分阈值，低于该分跳过不投；可用 BOSS_MIN_MATCH_SCORE 覆盖
+    min_llm_score = int(os.getenv("BOSS_MIN_MATCH_SCORE", "50"))
 
     # send_job_descriptions_to_chat 是 async 的（整段必须跑在同一个事件循环里，
     # 否则 nodriver CDP 会在 run_until_complete 之间进入半死态导致 evaluate hang）。
@@ -131,7 +136,7 @@ if __name__ == "__main__":
             usr_name, url, browser_type, label, "deepseek",
             vectorstore=vectorstore, dry_run=dry_run,
             resume_keywords=resume_keywords, resume_text=resume_text,
-            min_llm_score=50,
+            min_llm_score=min_llm_score,
         ))
     elif provider == "chatgpt":
         chatgpt_model = os.getenv("CHATGPT_MODEL", "").strip() or "gpt-4o"
@@ -150,7 +155,7 @@ if __name__ == "__main__":
             usr_name, url, browser_type, label, "chatgpt",
             client_openAI=client_openAI, assistant_id=assistant_id, dry_run=dry_run,
             resume_keywords=resume_keywords, resume_text=resume_text,
-            min_llm_score=50,
+            min_llm_score=min_llm_score,
         ))
     elif provider == "claude":
         vectorstore = embed_pdf(resume_path, "./vectorstores")
@@ -158,5 +163,5 @@ if __name__ == "__main__":
             usr_name, url, browser_type, label, "claude",
             vectorstore=vectorstore, dry_run=dry_run,
             resume_keywords=resume_keywords, resume_text=resume_text,
-            min_llm_score=50,
+            min_llm_score=min_llm_score,
         ))

--- a/models/job_matcher.py
+++ b/models/job_matcher.py
@@ -5,12 +5,16 @@
 """
 from __future__ import annotations
 
+import functools
 import logging
-import os
 import re
+import time
 
 from dotenv import load_dotenv
 from pypdf import PdfReader
+
+from audit.telemetry import record_llm_call
+from models.llm import _build_client, _call_chat_completion
 
 load_dotenv()
 log = logging.getLogger(__name__)
@@ -50,17 +54,43 @@ TECH_KEYWORDS = [
 ]
 
 
+@functools.lru_cache(maxsize=None)
+def _keyword_pattern(keyword: str) -> re.Pattern[str]:
+    """关键词 → 大小写不敏感的匹配 pattern。
+
+    纯 ASCII 关键词（"Go" / "AI" / "API"...）加词边界约束，避免子串误报：
+    "Go" 命中 "Google"、"AI" 命中 "Maintained"、"API" 命中 "Rapid"。
+    首/尾是非字母数字的（".NET" / "C++"）只约束字母数字那一侧，
+    保证 "ASP.NET"、"C++11" 仍能命中。含中文的关键词没有词边界概念，
+    保留子串匹配。
+    """
+    escaped = re.escape(keyword)
+    if keyword.isascii():
+        if keyword[0].isalnum():
+            escaped = r"(?<![A-Za-z0-9])" + escaped
+        if keyword[-1].isalnum():
+            escaped = escaped + r"(?![A-Za-z0-9])"
+    return re.compile(escaped, re.IGNORECASE)
+
+
+def _find_keywords(text: str, keywords: list[str]) -> list[str]:
+    return [kw for kw in keywords if _keyword_pattern(kw).search(text)]
+
+
 def extract_resume_text(pdf_path: str) -> str:
     """从 PDF 简历中提取全文文本。"""
     reader = PdfReader(pdf_path)
     return "\n".join(page.extract_text() or "" for page in reader.pages)
 
 
+def extract_keywords_from_text(resume_text: str) -> list[str]:
+    """从简历全文中提取技术关键词，大小写不敏感。"""
+    return _find_keywords(resume_text, TECH_KEYWORDS)
+
+
 def extract_keywords_from_resume(pdf_path: str) -> list[str]:
     """从简历 PDF 中自动提取关键词，大小写不敏感。"""
-    resume_text = extract_resume_text(pdf_path)
-    resume_upper = resume_text.upper()
-    return [kw for kw in TECH_KEYWORDS if kw.upper() in resume_upper]
+    return extract_keywords_from_text(extract_resume_text(pdf_path))
 
 
 def keyword_match(
@@ -69,8 +99,7 @@ def keyword_match(
     min_match: int = 2,
 ) -> tuple[bool, list[str]]:
     """第一层：关键词粗筛。JD 中至少命中 min_match 个简历关键词才通过。"""
-    jd_upper = job_description.upper()
-    matched = [kw for kw in resume_keywords if kw.upper() in jd_upper]
+    matched = _find_keywords(job_description, resume_keywords)
     return len(matched) >= min_match, matched
 
 
@@ -79,15 +108,16 @@ def llm_match_score(
     resume_text: str,
     matched_keywords: list[str],
 ) -> tuple[int, str]:
-    """第二层：LLM 精筛。评估简历与职位的匹配度，返回 0-100 分。"""
-    from openai import OpenAI
+    """第二层：LLM 精筛。评估简历与职位的匹配度，返回 0-100 分。
 
-    api_key = os.getenv("DEEPSEEK_API_KEY")
-    if not api_key:
+    评分链路任何一环不可用（缺 API key / 调用失败 / 回复解析不出分数）
+    都 fail-open 返回 100 放行——宁可少过滤，不能因为评分挂了把职位静默跳过。
+    """
+    try:
+        client, llm_model = _build_client("deepseek")
+    except RuntimeError:
         log.warning("DEEPSEEK_API_KEY 未设置，跳过 LLM 评分")
         return 100, "无法评分（缺少 API key）"
-
-    client = OpenAI(api_key=api_key, base_url="https://api.deepseek.com")
 
     prompt = f"""你是一位专业的招聘匹配分析师。请评估以下简历与职位描述的匹配程度。
 
@@ -111,27 +141,47 @@ def llm_match_score(
 - 50-69: 部分匹配，可以尝试
 - 0-49: 匹配度低，不建议投递"""
 
+    # _call_chat_completion 自带指数退避重试；评分调用跟招呼语生成一样
+    # 记 telemetry，不然每个职位多出来的这次调用成本不进 llm_calls.jsonl
+    t0 = time.monotonic()
     try:
-        response = client.chat.completions.create(
-            model="deepseek-chat",
+        response = _call_chat_completion(
+            client,
+            model=llm_model,
             messages=[{"role": "user", "content": prompt}],
             temperature=0.1,
             max_tokens=200,
         )
-        content = response.choices[0].message.content or ""
     except Exception as e:
+        record_llm_call(
+            provider="deepseek", model=llm_model,
+            input_tokens=0, output_tokens=0,
+            latency_ms=int((time.monotonic() - t0) * 1000),
+            ok=False, error=f"{type(e).__name__}: {e}",
+        )
         log.warning("LLM 评分调用失败: %s", e)
         return 100, f"评分失败（{e}）"
 
-    score = 0
-    reason = ""
-    score_match = re.search(r"分数:\s*(\d+)", content)
-    reason_match = re.search(r"理由:\s*(.+)", content)
-    if score_match:
-        score = min(100, max(0, int(score_match.group(1))))
-    if reason_match:
-        reason = reason_match.group(1).strip()
+    content = response.choices[0].message.content or ""
+    usage = getattr(response, "usage", None)
+    record_llm_call(
+        provider="deepseek", model=llm_model,
+        input_tokens=getattr(usage, "prompt_tokens", 0) if usage else 0,
+        output_tokens=getattr(usage, "completion_tokens", 0) if usage else 0,
+        latency_ms=int((time.monotonic() - t0) * 1000),
+        ok=True,
+    )
 
+    score_match = re.search(r"分数:\s*(\d+)", content)
+    if not score_match:
+        # LLM 没按格式回复时同样 fail-open；fail-closed（按 0 分算）
+        # 会把职位静默跳过，且日志里看不出原因
+        log.warning("LLM 评分回复解析失败，按 100 放行。回复内容: %r", content[:200])
+        return 100, "评分解析失败"
+
+    score = min(100, max(0, int(score_match.group(1))))
+    reason_match = re.search(r"理由:\s*(.+)", content)
+    reason = reason_match.group(1).strip() if reason_match else ""
     return score, reason
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,16 @@ dependencies = [
     "nodriver>=0.48.1",
 ]
 
+[project.optional-dependencies]
+# Tauri 桌面 App 才需要的额外依赖。CLI 模式（uv run main.py）不需要装。
+# 安装方式：uv sync --extra tauri
+tauri = [
+    "pydantic>=2.0",
+    "anyio>=4.0",
+    "pytauri==0.8.*",
+    "pytauri-wheel==0.8.*",
+]
+
 [tool.uv]
 package = false
 

--- a/tauri-ui/index.html
+++ b/tauri-ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BOSS Zhipin Helper</title>
+    <script type="module" src="/src/main.tsx" defer></script>
+  </head>
+  <body class="bg-slate-50">
+    <div id="root"></div>
+  </body>
+</html>

--- a/tauri-ui/package.json
+++ b/tauri-ui/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "boss-tauri-ui",
+  "private": true,
+  "version": "0.3.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^2.0.0",
+    "tauri-plugin-pytauri-api": "^0.8.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zustand": "^4.5.5"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.15",
+    "typescript": "~5.6.2",
+    "vite": "^6.3.6"
+  }
+}

--- a/tauri-ui/pnpm-lock.yaml
+++ b/tauri-ui/pnpm-lock.yaml
@@ -1,0 +1,1717 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.0.0
+        version: 2.11.0
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+      tauri-plugin-pytauri-api:
+        specifier: ^0.8.0
+        version: 0.8.0
+      zustand:
+        specifier: ^4.5.5
+        version: 4.5.7(@types/react@18.3.31)(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.7(@types/react@18.3.31)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.3(jiti@1.21.7))
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.5.0(postcss@8.5.15)
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.15
+      tailwindcss:
+        specifier: ^3.4.15
+        version: 3.4.19
+      typescript:
+        specifier: ~5.6.2
+        version: 5.6.3
+      vite:
+        specifier: ^6.3.6
+        version: 6.4.3(jiti@1.21.7)
+
+packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.61.1':
+    resolution: {integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    resolution: {integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.61.1':
+    resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    resolution: {integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    resolution: {integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    resolution: {integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    resolution: {integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    resolution: {integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@tauri-apps/api@2.11.0':
+    resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  autoprefixer@10.5.0:
+    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
+  baseline-browser-mapping@2.10.34:
+    resolution: {integrity: sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
+  caniuse-lite@1.0.30001797:
+    resolution: {integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  electron-to-chromium@1.5.368:
+    resolution: {integrity: sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.47:
+    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+    engines: {node: '>=18'}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-js@4.1.0:
+    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss-nested@6.2.0:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+
+  postcss-selector-parser@6.1.2:
+    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rollup@4.61.1:
+    resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  tailwindcss@3.4.19:
+    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  tauri-plugin-pytauri-api@0.8.0:
+    resolution: {integrity: sha512-mUw4JWTgHAdR1E4pJM+eCafS0E2ez3UEvC/NjkAOpzQuQjZ8u4CKikPJGoC2bTw5ABAmF68WkoOLySFYFbJp/Q==}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
+snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    optional: true
+
+  '@tauri-apps/api@2.11.0': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/estree@1.0.9': {}
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.31)':
+    dependencies:
+      '@types/react': 18.3.31
+
+  '@types/react@18.3.31':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(jiti@1.21.7))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(jiti@1.21.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  any-promise@1.3.0: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  arg@5.0.2: {}
+
+  autoprefixer@10.5.0(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001797
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  baseline-browser-mapping@2.10.34: {}
+
+  binary-extensions@2.3.0: {}
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.34
+      caniuse-lite: 1.0.30001797
+      electron-to-chromium: 1.5.368
+      node-releases: 2.0.47
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  camelcase-css@2.0.1: {}
+
+  caniuse-lite@1.0.30001797: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  commander@4.1.1: {}
+
+  convert-source-map@2.0.0: {}
+
+  cssesc@3.0.0: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  didyoumean@1.2.2: {}
+
+  dlv@1.1.3: {}
+
+  electron-to-chromium@1.5.368: {}
+
+  es-errors@1.3.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  escalade@3.2.0: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  fraction.js@5.3.4: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  jiti@1.21.7: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.12: {}
+
+  node-releases@2.0.47: {}
+
+  normalize-path@3.0.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
+
+  path-parse@1.0.7: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  pify@2.3.0: {}
+
+  pirates@4.0.7: {}
+
+  postcss-import@15.1.0(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.12
+
+  postcss-js@4.1.0(postcss@8.5.15):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.15
+
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 1.21.7
+      postcss: 8.5.15
+
+  postcss-nested@6.2.0(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-selector-parser: 6.1.2
+
+  postcss-selector-parser@6.1.2:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  queue-microtask@1.2.3: {}
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-refresh@0.17.0: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  reusify@1.1.0: {}
+
+  rollup@4.61.1:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.61.1
+      '@rollup/rollup-android-arm64': 4.61.1
+      '@rollup/rollup-darwin-arm64': 4.61.1
+      '@rollup/rollup-darwin-x64': 4.61.1
+      '@rollup/rollup-freebsd-arm64': 4.61.1
+      '@rollup/rollup-freebsd-x64': 4.61.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.61.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.61.1
+      '@rollup/rollup-linux-arm64-gnu': 4.61.1
+      '@rollup/rollup-linux-arm64-musl': 4.61.1
+      '@rollup/rollup-linux-loong64-gnu': 4.61.1
+      '@rollup/rollup-linux-loong64-musl': 4.61.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.61.1
+      '@rollup/rollup-linux-ppc64-musl': 4.61.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.61.1
+      '@rollup/rollup-linux-riscv64-musl': 4.61.1
+      '@rollup/rollup-linux-s390x-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-musl': 4.61.1
+      '@rollup/rollup-openbsd-x64': 4.61.1
+      '@rollup/rollup-openharmony-arm64': 4.61.1
+      '@rollup/rollup-win32-arm64-msvc': 4.61.1
+      '@rollup/rollup-win32-ia32-msvc': 4.61.1
+      '@rollup/rollup-win32-x64-gnu': 4.61.1
+      '@rollup/rollup-win32-x64-msvc': 4.61.1
+      fsevents: 2.3.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  semver@6.3.1: {}
+
+  source-map-js@1.2.1: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  tailwindcss@3.4.19:
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-import: 15.1.0(postcss@8.5.15)
+      postcss-js: 4.1.0(postcss@8.5.15)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)
+      postcss-nested: 6.2.0(postcss@8.5.15)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.12
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - tsx
+      - yaml
+
+  tauri-plugin-pytauri-api@0.8.0:
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  ts-interface-checker@0.1.13: {}
+
+  typescript@5.6.3: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
+  util-deprecate@1.0.2: {}
+
+  vite@6.4.3(jiti@1.21.7):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.61.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+      jiti: 1.21.7
+
+  yallist@3.1.1: {}
+
+  zustand@4.5.7(@types/react@18.3.31)(react@18.3.1):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      react: 18.3.1

--- a/tauri-ui/postcss.config.js
+++ b/tauri-ui/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tauri-ui/src/App.tsx
+++ b/tauri-ui/src/App.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import RunPage from "./pages/Run";
+import ConfigPage from "./pages/Config";
+import HistoryPage from "./pages/History";
+import { useRunStore } from "./store";
+
+type Tab = "run" | "config" | "history";
+
+export default function App() {
+  const [tab, setTab] = useState<Tab>("run");
+  const running = useRunStore((s) => s.running);
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="bg-white border-b border-slate-200 px-6 py-3 flex items-center gap-6">
+        <h1 className="text-lg font-semibold">BOSS Zhipin Helper</h1>
+        <nav className="flex gap-1">
+          <TabButton current={tab} value="run" onClick={setTab}>
+            运行 {running && <span className="ml-1 inline-block w-2 h-2 bg-green-500 rounded-full animate-pulse" />}
+          </TabButton>
+          <TabButton current={tab} value="config" onClick={setTab}>配置</TabButton>
+          <TabButton current={tab} value="history" onClick={setTab}>历史</TabButton>
+        </nav>
+        <span className="ml-auto text-xs text-slate-500">
+          自动化 Chrome 在另一个窗口，请勿手动关闭
+        </span>
+      </header>
+
+      <main className="flex-1 p-6 overflow-auto">
+        {tab === "run" && <RunPage />}
+        {tab === "config" && <ConfigPage />}
+        {tab === "history" && <HistoryPage />}
+      </main>
+    </div>
+  );
+}
+
+function TabButton({
+  current,
+  value,
+  onClick,
+  children,
+}: {
+  current: Tab;
+  value: Tab;
+  onClick: (t: Tab) => void;
+  children: React.ReactNode;
+}) {
+  const active = current === value;
+  return (
+    <button
+      onClick={() => onClick(value)}
+      className={`px-3 py-1.5 rounded-md text-sm transition-colors ${
+        active
+          ? "bg-slate-900 text-white"
+          : "text-slate-600 hover:bg-slate-100"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/tauri-ui/src/index.css
+++ b/tauri-ui/src/index.css
@@ -1,0 +1,9 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  body {
+    @apply font-sans antialiased text-slate-800;
+  }
+}

--- a/tauri-ui/src/lib/ipc.ts
+++ b/tauri-ui/src/lib/ipc.ts
@@ -1,0 +1,77 @@
+/** 类型化的 pyInvoke 封装，所有跟 Python 后端的 IPC 调用都从这里走。
+ * 改 backend 命令 / 返回类型时同步改这里，TypeScript 报错就是 contract 断了的信号。 */
+import { pyInvoke } from "tauri-plugin-pytauri-api";
+
+// ---------- types ----------
+
+export type EventKind =
+  | "browser_started"
+  | "login_ok"
+  | "job_found"
+  | "job_skipped"
+  | "letter_sent"
+  | "feed_exhausted"
+  | "loop_ended"
+  | "error";
+
+export type ProgressEvent = {
+  kind: EventKind;
+  payload: Record<string, unknown>;
+};
+
+export type RunConfig = {
+  usrName: string;
+  label: string;
+  provider: string;
+  dryRun: boolean;
+  resumePath?: string;
+};
+
+export type EnvField = {
+  key: string;
+  label: string;
+  isSecret: boolean;
+  value: string;
+};
+
+export type LetterRecord = {
+  ts: string;
+  provider: string;
+  model: string;
+  dry_run: boolean;
+  validation_ok: boolean;
+  validation_reasons: string[];
+  sent: boolean;
+  letter_len: number;
+  job_description: string;
+  letter: string;
+};
+
+export type TelemetrySummary = {
+  total_calls: number;
+  total_cost_cny: number;
+  by_provider: Record<string, {
+    calls: number;
+    input_tokens: number;
+    output_tokens: number;
+    cost_cny: number;
+  }>;
+};
+
+// ---------- wrappers ----------
+
+export const ipc = {
+  detectProviders: () => pyInvoke<{ providers: string[] }>("detect_providers", {}),
+  isRunning: () => pyInvoke<{ running: boolean }>("is_running", {}),
+  startRun: (config: RunConfig, progressChannel: unknown, logChannel: unknown) =>
+    pyInvoke<{ status: string }>("start_run", { config, progressChannel, logChannel }),
+  stopRun: () => pyInvoke<{ status: string }>("stop_run", {}),
+  shutdownBrowser: () => pyInvoke<{ status: string }>("shutdown_browser", {}),
+  getEnvFields: () => pyInvoke<{ fields: EnvField[] }>("get_env_fields", {}),
+  writeEnvFields: (updates: Record<string, string>) =>
+    pyInvoke<{ status: string }>("write_env_fields", { updates }),
+  getLetters: (limit: number = 200) =>
+    pyInvoke<{ letters: LetterRecord[] }>("get_letters", { limit }),
+  getTelemetrySummary: () =>
+    pyInvoke<{ summary: TelemetrySummary }>("get_telemetry_summary", {}),
+};

--- a/tauri-ui/src/main.tsx
+++ b/tauri-ui/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/tauri-ui/src/pages/Config.tsx
+++ b/tauri-ui/src/pages/Config.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { ipc, type EnvField } from "../lib/ipc";
+
+export default function ConfigPage() {
+  const [fields, setFields] = useState<EnvField[]>([]);
+  const [edits, setEdits] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const { fields } = await ipc.getEnvFields();
+      setFields(fields);
+      setEdits({});
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function setField(key: string, value: string) {
+    setSaved(false);
+    setEdits((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function valueFor(key: string, fallback: string): string {
+    return key in edits ? edits[key] : fallback;
+  }
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      await ipc.writeEnvFields(edits);
+      setSaved(true);
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const dirty = Object.keys(edits).length > 0;
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <div className="bg-white p-6 rounded-lg shadow-sm border border-slate-200">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="font-semibold">配置 (.env)</h2>
+          <div className="flex items-center gap-3">
+            {saved && !dirty && (
+              <span className="text-sm text-emerald-600">✓ 已保存</span>
+            )}
+            <button
+              onClick={save}
+              disabled={!dirty || saving}
+              className="px-4 py-1.5 bg-slate-900 text-white rounded text-sm disabled:opacity-50"
+            >
+              {saving ? "保存中..." : "保存"}
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="bg-red-50 text-red-700 border border-red-200 rounded p-3 mb-4 text-sm">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="text-slate-500">加载中...</div>
+        ) : (
+          <div className="space-y-3">
+            {fields.map((f) => (
+              <div key={f.key}>
+                <label className="block text-sm text-slate-600 mb-1">
+                  <span className="font-mono text-xs bg-slate-100 px-1.5 py-0.5 rounded mr-2">
+                    {f.key}
+                  </span>
+                  {f.label}
+                </label>
+                <input
+                  type={f.isSecret ? "password" : "text"}
+                  value={valueFor(f.key, f.value)}
+                  onChange={(e) => setField(f.key, e.target.value)}
+                  className="w-full px-3 py-1.5 border border-slate-300 rounded text-sm font-mono"
+                  placeholder={f.isSecret ? "（已设，留空覆盖为删除）" : ""}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        <p className="mt-4 text-xs text-slate-500">
+          保存后 .env 立刻更新；但 LLM client 在程序启动时已经读过 API key，
+          要让新值生效请退出 App 重新打开。
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/tauri-ui/src/pages/History.tsx
+++ b/tauri-ui/src/pages/History.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from "react";
+import { ipc, type LetterRecord, type TelemetrySummary } from "../lib/ipc";
+
+export default function HistoryPage() {
+  const [letters, setLetters] = useState<LetterRecord[]>([]);
+  const [summary, setSummary] = useState<TelemetrySummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [{ letters }, { summary }] = await Promise.all([
+        ipc.getLetters(200),
+        ipc.getTelemetrySummary(),
+      ]);
+      setLetters(letters.reverse()); // 最新的在最上
+      setSummary(summary);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold">历史</h2>
+        <button
+          onClick={refresh}
+          disabled={loading}
+          className="px-3 py-1 text-sm border border-slate-300 rounded hover:bg-slate-100"
+        >
+          {loading ? "..." : "刷新"}
+        </button>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 text-red-700 border border-red-200 rounded p-3 text-sm">
+          {error}
+        </div>
+      )}
+
+      {summary && <CostSummary summary={summary} />}
+
+      <div className="bg-white rounded-lg shadow-sm border border-slate-200 overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 border-b border-slate-200">
+            <tr className="text-left text-xs text-slate-600">
+              <th className="px-3 py-2">时间</th>
+              <th className="px-3 py-2">Provider</th>
+              <th className="px-3 py-2">Model</th>
+              <th className="px-3 py-2 text-center">校验</th>
+              <th className="px-3 py-2 text-center">发送</th>
+              <th className="px-3 py-2">招呼语</th>
+            </tr>
+          </thead>
+          <tbody>
+            {letters.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-3 py-4 text-center text-slate-400">
+                  {loading ? "加载中..." : "logs/letters.jsonl 是空的——还没生成过招呼语"}
+                </td>
+              </tr>
+            ) : (
+              letters.map((l, i) => <LetterRow key={i} l={l} />)
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function CostSummary({ summary }: { summary: TelemetrySummary }) {
+  const providers = Object.entries(summary.by_provider);
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-slate-200 p-4">
+      <h3 className="font-medium text-sm text-slate-700 mb-3">LLM 调用成本（最近 1000 次）</h3>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+        <Stat label="总调用次数" value={summary.total_calls.toString()} />
+        <Stat label="总成本 (¥)" value={summary.total_cost_cny.toFixed(4)} />
+        {providers.map(([provider, s]) => (
+          <Stat
+            key={provider}
+            label={`${provider} (${s.calls} 次)`}
+            value={`¥ ${s.cost_cny.toFixed(4)}`}
+            sub={`in: ${s.input_tokens}  out: ${s.output_tokens}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="bg-slate-50 rounded p-2">
+      <div className="text-xs text-slate-500">{label}</div>
+      <div className="font-mono text-base mt-0.5">{value}</div>
+      {sub && <div className="text-xs text-slate-400 mt-0.5">{sub}</div>}
+    </div>
+  );
+}
+
+function LetterRow({ l }: { l: LetterRecord }) {
+  const [expanded, setExpanded] = useState(false);
+  const time = new Date(l.ts).toLocaleString();
+  return (
+    <>
+      <tr className="border-b border-slate-100 hover:bg-slate-50 cursor-pointer" onClick={() => setExpanded(!expanded)}>
+        <td className="px-3 py-2 text-xs text-slate-600 whitespace-nowrap">{time}</td>
+        <td className="px-3 py-2 text-xs">{l.provider}</td>
+        <td className="px-3 py-2 text-xs">{l.model}</td>
+        <td className="px-3 py-2 text-center">
+          {l.validation_ok ? (
+            <span className="text-emerald-600">✓</span>
+          ) : (
+            <span className="text-red-600" title={l.validation_reasons.join(", ")}>✗</span>
+          )}
+        </td>
+        <td className="px-3 py-2 text-center text-xs">
+          {l.sent ? "已发" : l.dry_run ? "DRY" : "—"}
+        </td>
+        <td className="px-3 py-2 text-xs">
+          {expanded ? l.letter : l.letter.slice(0, 60) + (l.letter.length > 60 ? "..." : "")}
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="border-b border-slate-200 bg-slate-50">
+          <td colSpan={6} className="px-3 py-3 text-xs">
+            <div className="mb-2">
+              <span className="font-medium text-slate-700">JD 预览：</span>
+              <span className="text-slate-600 ml-1">
+                {l.job_description.slice(0, 300)}{l.job_description.length > 300 && "..."}
+              </span>
+            </div>
+            {!l.validation_ok && (
+              <div className="text-red-700">
+                <span className="font-medium">校验失败：</span>
+                {l.validation_reasons.join(", ")}
+              </div>
+            )}
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}

--- a/tauri-ui/src/pages/Run.tsx
+++ b/tauri-ui/src/pages/Run.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useRef, useState } from "react";
+import { Channel } from "@tauri-apps/api/core";
+import { ipc, type ProgressEvent, type RunConfig } from "../lib/ipc";
+import { useRunStore } from "../store";
+
+export default function RunPage() {
+  const [providers, setProviders] = useState<string[]>([]);
+  const [providersError, setProvidersError] = useState<string | null>(null);
+  const [usrName, setUsrName] = useState("");
+  const [label, setLabel] = useState("");
+  const [provider, setProvider] = useState("");
+  const [dryRun, setDryRun] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  const running = useRunStore((s) => s.running);
+  const events = useRunStore((s) => s.events);
+  const logs = useRunStore((s) => s.logs);
+  const currentIndex = useRunStore((s) => s.currentIndex);
+  const setRunning = useRunStore((s) => s.setRunning);
+  const pushEvent = useRunStore((s) => s.pushEvent);
+  const pushLog = useRunStore((s) => s.pushLog);
+  const clear = useRunStore((s) => s.clear);
+
+  const logScrollRef = useRef<HTMLPreElement>(null);
+  const eventsScrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    ipc.detectProviders()
+      .then(({ providers }) => {
+        setProviders(providers);
+        if (providers.length > 0) setProvider(providers[0]);
+      })
+      .catch((e) => setProvidersError(String(e)));
+  }, []);
+
+  // 自动滚动
+  useEffect(() => {
+    if (logScrollRef.current) {
+      logScrollRef.current.scrollTop = logScrollRef.current.scrollHeight;
+    }
+  }, [logs.length]);
+  useEffect(() => {
+    if (eventsScrollRef.current) {
+      eventsScrollRef.current.scrollTop = eventsScrollRef.current.scrollHeight;
+    }
+  }, [events.length]);
+
+  async function handleStart() {
+    if (!usrName.trim()) {
+      alert("请填用户名");
+      return;
+    }
+    if (!provider) {
+      alert("没有可用的 provider，先去配置 tab 填 API key");
+      return;
+    }
+    setBusy(true);
+    clear();
+    setRunning(true);
+
+    const progressChannel = new Channel<ProgressEvent>((ev) => pushEvent(ev));
+    const logChannel = new Channel<string>((line) => pushLog(line));
+
+    const config: RunConfig = {
+      usrName: usrName.trim(),
+      label: label.trim(),
+      provider,
+      dryRun,
+    };
+
+    try {
+      await ipc.startRun(config, progressChannel, logChannel);
+    } catch (e) {
+      pushLog(`[start_run 失败] ${e}`);
+      setRunning(false);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleStop() {
+    setBusy(true);
+    try {
+      await ipc.stopRun();
+    } catch (e) {
+      pushLog(`[stop_run 失败] ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleReset() {
+    setBusy(true);
+    try {
+      await ipc.shutdownBrowser();
+      pushLog("[已关 Chrome，下次启动会重新打开]");
+    } catch (e) {
+      pushLog(`[shutdown_browser 失败] ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-4">
+      <div className="bg-white p-4 rounded-lg shadow-sm border border-slate-200">
+        <div className="grid grid-cols-2 gap-4">
+          <Field label="你的名字（招呼语署名）">
+            <input
+              type="text"
+              value={usrName}
+              onChange={(e) => setUsrName(e.target.value)}
+              disabled={running}
+              className="input"
+              placeholder="必填"
+            />
+          </Field>
+          <Field label="求职 tag">
+            <input
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              disabled={running}
+              className="input"
+              placeholder="留空走 BOSS 推荐 feed"
+            />
+          </Field>
+          <Field label="Provider">
+            {providersError ? (
+              <span className="text-red-600 text-sm">检测失败: {providersError}</span>
+            ) : providers.length === 0 ? (
+              <span className="text-amber-600 text-sm">
+                没检测到 API key —— 去配置 tab 填一个
+              </span>
+            ) : (
+              <select
+                value={provider}
+                onChange={(e) => setProvider(e.target.value)}
+                disabled={running}
+                className="input"
+              >
+                {providers.map((p) => (
+                  <option key={p} value={p}>{p}</option>
+                ))}
+              </select>
+            )}
+          </Field>
+          <Field label="">
+            <label className="inline-flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={dryRun}
+                onChange={(e) => setDryRun(e.target.checked)}
+                disabled={running}
+              />
+              DRY-RUN（只生成不发送）
+            </label>
+          </Field>
+        </div>
+
+        <div className="flex items-center gap-3 mt-4">
+          <button
+            onClick={handleStart}
+            disabled={running || busy}
+            className="btn-primary"
+          >
+            开始
+          </button>
+          <button
+            onClick={handleStop}
+            disabled={!running || busy}
+            className="btn-danger"
+          >
+            停止
+          </button>
+          <button
+            onClick={handleReset}
+            disabled={running || busy}
+            className="btn-secondary"
+          >
+            重置 Chrome
+          </button>
+          <span className="ml-auto text-sm text-slate-600">
+            {running
+              ? currentIndex !== null
+                ? `运行中 · 当前 job #${currentIndex}`
+                : "运行中..."
+              : "idle"}
+          </span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <Panel title="进度事件">
+          <div
+            ref={eventsScrollRef}
+            className="bg-slate-50 rounded p-3 text-xs font-mono h-72 overflow-y-auto"
+          >
+            {events.length === 0 ? (
+              <div className="text-slate-400">还没事件</div>
+            ) : (
+              events.map((ev, i) => <EventRow key={i} ev={ev} />)
+            )}
+          </div>
+        </Panel>
+
+        <Panel title="日志">
+          <pre
+            ref={logScrollRef}
+            className="bg-slate-900 text-slate-100 rounded p-3 text-xs font-mono h-72 overflow-y-auto whitespace-pre-wrap"
+          >
+            {logs.length === 0 ? <span className="text-slate-500">还没日志</span> : logs.join("\n")}
+          </pre>
+        </Panel>
+      </div>
+
+      <style>{`
+        .input {
+          padding: 0.4rem 0.6rem; font-size: 14px;
+          border: 1px solid #cbd5e1; border-radius: 0.375rem;
+          background: white; outline: none; transition: border-color 0.15s;
+          width: 100%;
+        }
+        .input:focus { border-color: #64748b; }
+        .input:disabled { background: #f1f5f9; color: #64748b; }
+        .btn-primary {
+          padding: 0.5rem 1.25rem; font-size: 14px; font-weight: 500;
+          background: #16a34a; color: white; border-radius: 0.375rem;
+          transition: background 0.15s;
+        }
+        .btn-primary:hover:not(:disabled) { background: #15803d; }
+        .btn-danger {
+          padding: 0.5rem 1.25rem; font-size: 14px; font-weight: 500;
+          background: #dc2626; color: white; border-radius: 0.375rem;
+        }
+        .btn-danger:hover:not(:disabled) { background: #b91c1c; }
+        .btn-secondary {
+          padding: 0.5rem 1.25rem; font-size: 14px; font-weight: 500;
+          background: white; color: #475569; border: 1px solid #cbd5e1;
+          border-radius: 0.375rem;
+        }
+        .btn-secondary:hover:not(:disabled) { background: #f1f5f9; }
+        .btn-primary:disabled, .btn-danger:disabled, .btn-secondary:disabled {
+          opacity: 0.5; cursor: not-allowed;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      {label && <label className="block text-sm text-slate-600 mb-1">{label}</label>}
+      {children}
+    </div>
+  );
+}
+
+function Panel({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-white p-4 rounded-lg shadow-sm border border-slate-200">
+      <h3 className="font-medium text-sm text-slate-700 mb-2">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+const KIND_STYLES: Record<string, string> = {
+  browser_started: "text-slate-500",
+  login_ok: "text-emerald-700",
+  job_found: "text-blue-700",
+  job_skipped: "text-slate-500",
+  letter_sent: "text-emerald-700 font-medium",
+  feed_exhausted: "text-purple-700 font-medium",
+  loop_ended: "text-purple-700 font-medium",
+  error: "text-red-700 font-medium",
+};
+
+function EventRow({ ev }: { ev: ProgressEvent }) {
+  const payload = Object.entries(ev.payload)
+    .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+    .join(" ");
+  return (
+    <div className={`py-0.5 ${KIND_STYLES[ev.kind] ?? "text-slate-700"}`}>
+      <span className="opacity-70">[{ev.kind}]</span> {payload}
+    </div>
+  );
+}

--- a/tauri-ui/src/store.ts
+++ b/tauri-ui/src/store.ts
@@ -1,0 +1,43 @@
+/** 全局状态：当前是否在 run、最近事件、最近日志。Zustand。
+ * 之所以全局：跨 tab 切换不丢运行状态 + 不丢已收的事件。 */
+import { create } from "zustand";
+import type { ProgressEvent } from "./lib/ipc";
+
+const MAX_EVENTS = 500;
+const MAX_LOGS = 1000;
+
+type RunState = {
+  running: boolean;
+  events: ProgressEvent[];
+  logs: string[];
+  currentIndex: number | null;  // 当前 job_index（从 job_found 提取）
+
+  setRunning: (running: boolean) => void;
+  pushEvent: (ev: ProgressEvent) => void;
+  pushLog: (line: string) => void;
+  clear: () => void;
+};
+
+export const useRunStore = create<RunState>((set) => ({
+  running: false,
+  events: [],
+  logs: [],
+  currentIndex: null,
+
+  setRunning: (running) => set({ running }),
+  pushEvent: (ev) =>
+    set((s) => {
+      const events = [...s.events, ev].slice(-MAX_EVENTS);
+      let currentIndex = s.currentIndex;
+      if (ev.kind === "job_found" && typeof ev.payload.index === "number") {
+        currentIndex = ev.payload.index;
+      }
+      let running = s.running;
+      if (ev.kind === "loop_ended") {
+        running = false;
+      }
+      return { events, currentIndex, running };
+    }),
+  pushLog: (line) => set((s) => ({ logs: [...s.logs, line].slice(-MAX_LOGS) })),
+  clear: () => set({ events: [], logs: [], currentIndex: null }),
+}));

--- a/tauri-ui/tailwind.config.js
+++ b/tauri-ui/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tauri-ui/tsconfig.json
+++ b/tauri-ui/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src/**/*"]
+}

--- a/tauri-ui/vite.config.ts
+++ b/tauri-ui/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: "../boss_tauri/frontend",
+    emptyOutDir: true,
+  },
+  server: {
+    port: 1420,
+    strictPort: true,
+  },
+});

--- a/tests/test_job_matcher.py
+++ b/tests/test_job_matcher.py
@@ -1,0 +1,184 @@
+"""``models/job_matcher.py`` 的单元测试。
+
+覆盖：
+- 关键词提取/匹配：词边界（短英文词不被子串误报）、中文子串、特殊符号关键词
+- ``llm_match_score``：正常解析、分数钳位、三种 fail-open（缺 key / 调用失败 /
+  回复解析不出分数）、telemetry 落盘
+- ``should_apply``：关键词层拒绝、LLM 层通过/拒绝
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from models import job_matcher
+from models.job_matcher import (
+    extract_keywords_from_text,
+    keyword_match,
+    llm_match_score,
+    should_apply,
+)
+
+
+def _fake_response(content: str):
+    """构造一个最小的 chat.completions response 替身。"""
+    message = types.SimpleNamespace(content=content)
+    choice = types.SimpleNamespace(message=message)
+    usage = types.SimpleNamespace(prompt_tokens=100, completion_tokens=20)
+    return types.SimpleNamespace(choices=[choice], usage=usage)
+
+
+@pytest.fixture
+def telemetry_spy(monkeypatch):
+    """把 record_llm_call 换成 spy，避免测试往 logs/ 写文件。"""
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        job_matcher, "record_llm_call", lambda **kwargs: calls.append(kwargs)
+    )
+    return calls
+
+
+@pytest.fixture
+def fake_client(monkeypatch):
+    """绕开 _build_client 的真实 env 检查。"""
+    monkeypatch.setattr(
+        job_matcher, "_build_client", lambda provider: (object(), "deepseek-chat")
+    )
+
+
+# ---------- 关键词提取 / 匹配 ----------
+
+class TestExtractKeywords:
+    def test_happy_path(self):
+        text = "精通 Python 和 Django，熟悉 Docker 容器化部署，有机器学习项目经验"
+        keywords = extract_keywords_from_text(text)
+        assert {"Python", "Django", "Docker", "机器学习"} <= set(keywords)
+
+    def test_short_keywords_not_matched_as_substring(self):
+        # "Go" 不该命中 Google、"AI" 不该命中 Maintained、"API" 不该命中 Rapid
+        text = "Maintained legacy services at Google with rapid iteration"
+        keywords = extract_keywords_from_text(text)
+        assert "Go" not in keywords
+        assert "AI" not in keywords
+        assert "API" not in keywords
+
+    def test_short_keywords_matched_at_word_boundary(self):
+        # 中文紧贴英文关键词是 BOSS JD 的常态，必须能命中
+        text = "负责AI产品研发，使用Go语言开发RESTful API服务"
+        keywords = extract_keywords_from_text(text)
+        assert {"AI", "Go", "API", "RESTful"} <= set(keywords)
+
+    def test_keywords_with_special_chars(self):
+        # ".NET" 要能命中 "ASP.NET"，"C++" 要能命中 "C++11"
+        text = "5年 ASP.NET 开发经验，熟悉 C++11 标准和 Node.js"
+        keywords = extract_keywords_from_text(text)
+        assert {".NET", "C++", "Node.js"} <= set(keywords)
+
+    def test_case_insensitive(self):
+        keywords = extract_keywords_from_text("熟悉 PYTHON 和 docker")
+        assert {"Python", "Docker"} <= set(keywords)
+
+
+class TestKeywordMatch:
+    def test_passes_at_threshold(self):
+        passed, matched = keyword_match(
+            "招聘 Python 后端，熟悉 Redis 优先", ["Python", "Redis", "Go"], min_match=2
+        )
+        assert passed
+        assert set(matched) == {"Python", "Redis"}
+
+    def test_rejects_below_threshold(self):
+        passed, matched = keyword_match(
+            "招聘 Java 开发", ["Python", "Redis", "Go"], min_match=2
+        )
+        assert not passed
+        assert matched == []
+
+
+# ---------- llm_match_score ----------
+
+class TestLlmMatchScore:
+    def test_parses_score_and_reason(self, monkeypatch, fake_client, telemetry_spy):
+        monkeypatch.setattr(
+            job_matcher, "_call_chat_completion",
+            lambda client, **kwargs: _fake_response("分数: 85\n理由: 技能高度匹配"),
+        )
+        score, reason = llm_match_score("JD", "简历", ["Python"])
+        assert score == 85
+        assert reason == "技能高度匹配"
+        # telemetry 记了一条成功调用
+        assert len(telemetry_spy) == 1
+        assert telemetry_spy[0]["ok"] is True
+        assert telemetry_spy[0]["input_tokens"] == 100
+
+    def test_score_clamped_to_100(self, monkeypatch, fake_client, telemetry_spy):
+        monkeypatch.setattr(
+            job_matcher, "_call_chat_completion",
+            lambda client, **kwargs: _fake_response("分数: 150\n理由: 超纲了"),
+        )
+        score, _ = llm_match_score("JD", "简历", [])
+        assert score == 100
+
+    def test_fail_open_without_api_key(self, monkeypatch):
+        # conftest 已清空 env；这里再兜一层防本机 .env 经 load_dotenv 漏进来
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+        score, reason = llm_match_score("JD", "简历", [])
+        assert score == 100
+        assert "API key" in reason
+
+    def test_fail_open_on_api_error(self, monkeypatch, fake_client, telemetry_spy):
+        def boom(client, **kwargs):
+            raise ConnectionError("network down")
+
+        monkeypatch.setattr(job_matcher, "_call_chat_completion", boom)
+        score, reason = llm_match_score("JD", "简历", [])
+        assert score == 100
+        assert "评分失败" in reason
+        # 失败也要记 telemetry
+        assert telemetry_spy[0]["ok"] is False
+
+    def test_fail_open_on_unparseable_reply(self, monkeypatch, fake_client, telemetry_spy):
+        # LLM 没按 "分数: NN" 格式回复 → 必须放行，不能按 0 分静默跳过
+        monkeypatch.setattr(
+            job_matcher, "_call_chat_completion",
+            lambda client, **kwargs: _fake_response("我觉得这个职位很适合你！"),
+        )
+        score, reason = llm_match_score("JD", "简历", [])
+        assert score == 100
+        assert "解析失败" in reason
+
+
+# ---------- should_apply ----------
+
+class TestShouldApply:
+    def test_rejected_at_keyword_stage(self):
+        apply, details = should_apply(
+            "招聘销售经理", ["Python", "Docker"], "简历全文", min_keyword_match=2
+        )
+        assert not apply
+        assert details["stage"] == "keyword"
+        assert "score" not in details
+
+    def test_passes_both_stages(self, monkeypatch):
+        monkeypatch.setattr(
+            job_matcher, "llm_match_score", lambda jd, resume, kws: (80, "匹配")
+        )
+        apply, details = should_apply(
+            "招聘 Python 工程师，熟悉 Docker", ["Python", "Docker"], "简历全文",
+            min_llm_score=70,
+        )
+        assert apply
+        assert details["stage"] == "llm"
+        assert details["score"] == 80
+
+    def test_rejected_at_llm_stage(self, monkeypatch):
+        monkeypatch.setattr(
+            job_matcher, "llm_match_score", lambda jd, resume, kws: (40, "匹配度低")
+        )
+        apply, details = should_apply(
+            "招聘 Python 工程师，熟悉 Docker", ["Python", "Docker"], "简历全文",
+            min_llm_score=70,
+        )
+        assert not apply
+        assert details["score"] == 40

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,213 @@
+"""``gui/runner.py`` + ``gui/events.py`` + ``gui/log_bridge.py`` 的单测。
+
+不依赖 NiceGUI / PyTauri / nodriver——直接用 ``asyncio.sleep`` 和 raise
+模拟主循环，验证 runner 的状态机和 emit 路由正确。
+
+项目没装 pytest-asyncio，每个用例自己用 ``asyncio.run`` 包一下。
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from gui import events as gui_events
+from gui import log_bridge
+from gui import runner
+
+
+@pytest.fixture(autouse=True)
+def _reset_runner_state():
+    """每个用例跑前后都重置模块级状态，避免互相污染。"""
+    runner.reset()
+    yield
+    runner.reset()
+
+
+def test_start_then_completes_emits_loop_ended_completed():
+    async def scenario():
+        events: list[gui_events.ProgressEvent] = []
+
+        async def fast_loop():
+            gui_events.emit("browser_started")
+
+        task = runner.start_run(fast_loop, on_event=events.append)
+        await task
+        kinds = [e.kind for e in events]
+        assert kinds == ["browser_started", "loop_ended"]
+        assert events[-1].payload["reason"] == "completed"
+
+    asyncio.run(scenario())
+
+
+def test_start_twice_raises():
+    async def scenario():
+        async def slow_loop():
+            await asyncio.sleep(10)
+
+        runner.start_run(slow_loop)
+        try:
+            with pytest.raises(RuntimeError, match="already in progress"):
+                runner.start_run(slow_loop)
+        finally:
+            await runner.stop_run()
+
+    asyncio.run(scenario())
+
+
+def test_stop_cancels_and_emits_cancelled():
+    async def scenario():
+        events: list[gui_events.ProgressEvent] = []
+        started = asyncio.Event()
+
+        async def loop_until_cancelled():
+            gui_events.emit("browser_started")
+            started.set()
+            await asyncio.sleep(30)
+
+        runner.start_run(loop_until_cancelled, on_event=events.append)
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        stopped = await runner.stop_run(timeout=5.0)
+        assert stopped is True
+        kinds = [e.kind for e in events]
+        assert "browser_started" in kinds
+        assert kinds[-1] == "loop_ended"
+        assert events[-1].payload["reason"] == "cancelled"
+
+    asyncio.run(scenario())
+
+
+def test_stop_when_idle_returns_false():
+    async def scenario():
+        assert await runner.stop_run() is False
+
+    asyncio.run(scenario())
+
+
+def test_exception_emits_error_and_loop_ended():
+    async def scenario():
+        events: list[gui_events.ProgressEvent] = []
+
+        async def crashing_loop():
+            gui_events.emit("browser_started")
+            raise ValueError("boom")
+
+        task = runner.start_run(crashing_loop, on_event=events.append)
+        await task  # runner swallows exception internally
+        kinds = [e.kind for e in events]
+        assert kinds == ["browser_started", "error", "loop_ended"]
+        error_event = events[1]
+        assert error_event.payload["stage"] == "main_loop"
+        assert "ValueError" in error_event.payload["message"]
+        assert "boom" in error_event.payload["message"]
+        assert events[-1].payload["reason"] == "error"
+
+    asyncio.run(scenario())
+
+
+def test_emit_helper_noop_when_no_callback():
+    """CLI 模式（没有 set_emit_callback）emit 必须 no-op，不抛。"""
+    gui_events.emit("browser_started")
+    gui_events.emit("job_found", index=3, jd_preview="后端")
+    # 不抛即通过
+
+
+def test_emit_callback_swallows_exceptions():
+    """callback 抛异常不能传播给业务代码。"""
+    def angry_cb(ev):
+        raise RuntimeError("UI bug!")
+
+    gui_events.set_emit_callback(angry_cb)
+    try:
+        gui_events.emit("browser_started")  # 不应抛
+    finally:
+        gui_events.set_emit_callback(None)
+
+
+def test_callback_cleared_after_natural_completion():
+    """run 自然结束（不靠 stop_run）后 emit 应该回到 no-op，
+    防止下次 start_run 之前的旧 callback 还在收事件。"""
+    async def scenario():
+        events: list[gui_events.ProgressEvent] = []
+
+        async def trivial():
+            return
+
+        task = runner.start_run(trivial, on_event=events.append)
+        await task
+        n_before = len(events)
+        gui_events.emit("browser_started")  # 应该是 no-op
+        assert len(events) == n_before
+
+    asyncio.run(scenario())
+
+
+def test_callback_cleared_after_cancel():
+    """cancel 路径同样要清 callback。"""
+    async def scenario():
+        events: list[gui_events.ProgressEvent] = []
+        started = asyncio.Event()
+
+        async def slow():
+            started.set()
+            await asyncio.sleep(30)
+
+        runner.start_run(slow, on_event=events.append)
+        await started.wait()
+        await runner.stop_run(timeout=2)
+        n_before = len(events)
+        gui_events.emit("browser_started")  # 应该是 no-op
+        assert len(events) == n_before
+
+    asyncio.run(scenario())
+
+
+def test_pydantic_event_serializes():
+    """ProgressEvent 是 Pydantic model，能 dump 成 dict 喂 PyTauri Channel。"""
+    ev = gui_events.ProgressEvent(kind="job_found", payload={"index": 3, "jd_preview": "Hi"})
+    d = ev.model_dump()
+    assert d["kind"] == "job_found"
+    assert d["payload"]["index"] == 3
+
+
+def test_log_bridge_captures_logger_output():
+    """log_bridge install 后，logging 调用必须出现在 callback 里。"""
+    msgs: list[str] = []
+    handler = log_bridge.install(msgs.append, level=logging.INFO)
+    try:
+        log = logging.getLogger("test_runner.bridge")
+        log.setLevel(logging.INFO)
+        log.info("hello bridge")
+        assert any("hello bridge" in m for m in msgs)
+    finally:
+        log_bridge.uninstall(handler)
+
+
+def test_log_bridge_install_replaces_previous():
+    """重复 install 应卸掉旧 handler，否则同条日志被推 2 次。"""
+    msgs1: list[str] = []
+    msgs2: list[str] = []
+    h1 = log_bridge.install(msgs1.append, level=logging.INFO)
+    h2 = log_bridge.install(msgs2.append, level=logging.INFO)
+    try:
+        log = logging.getLogger("test_runner.replace")
+        log.setLevel(logging.INFO)
+        log.info("ping")
+        assert len(msgs1) == 0
+        assert len(msgs2) == 1
+    finally:
+        log_bridge.uninstall(h2)
+        log_bridge.uninstall(h1)
+
+
+def test_log_bridge_callback_exception_swallowed():
+    """callback 抛异常不能让 logger 挂。"""
+    def angry(msg):
+        raise RuntimeError("UI bug")
+
+    h = log_bridge.install(angry, level=logging.INFO)
+    try:
+        logging.getLogger("test_runner.angry").info("ping")  # 不应抛
+    finally:
+        log_bridge.uninstall(h)

--- a/uv.lock
+++ b/uv.lock
@@ -131,6 +131,14 @@ dependencies = [
     { name = "sentence-transformers" },
 ]
 
+[package.optional-dependencies]
+tauri = [
+    { name = "anyio" },
+    { name = "pydantic" },
+    { name = "pytauri" },
+    { name = "pytauri-wheel" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -138,14 +146,19 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", marker = "extra == 'tauri'", specifier = ">=4.0" },
     { name = "chromadb", specifier = ">=0.6.3" },
     { name = "nodriver", specifier = ">=0.48.1" },
     { name = "openai", specifier = ">=1.70.0" },
     { name = "packaging", specifier = ">=24.2" },
+    { name = "pydantic", marker = "extra == 'tauri'", specifier = ">=2.0" },
     { name = "pypdf", specifier = ">=5.4.0" },
+    { name = "pytauri", marker = "extra == 'tauri'", specifier = "==0.8.*" },
+    { name = "pytauri-wheel", marker = "extra == 'tauri'", specifier = "==0.8.*" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "sentence-transformers", specifier = ">=3.0.0" },
 ]
+provides-extras = ["tauri"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.0.3" }]
@@ -1324,6 +1337,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/3f/8de630f595daf6ce884d4dd95afd2a60e70ec6572e52bfee3aa2229befab/onnxruntime-1.26.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11a8df4dcfe9ad5ff0bd71a7571dbed019fabc7594676c89fe8b86ea029c246f", size = 18176043, upload-time = "2026-05-08T19:07:33.735Z" },
     { url = "https://files.pythonhosted.org/packages/9c/21/9f041de20787cd85498bd48e0ec4d098bf2a6c486e25b24b8dae1bf492b2/onnxruntime-1.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:e6456718125fd777c673f3b78d4a9ab58d6adea641e9afae85ee6444f0e0e9a9", size = 13023165, upload-time = "2026-05-08T19:08:00.633Z" },
     { url = "https://files.pythonhosted.org/packages/0e/82/3b9fe0ead2557cc3adf74c74c141bd1c7c4c6a9548c610af37df199f4512/onnxruntime-1.26.0-cp311-cp311-win_arm64.whl", hash = "sha256:cd920e45b730e4a87833e2910d8ca375aaca9da6ccc09e24bce463b3356d637f", size = 12789514, upload-time = "2026-05-08T19:07:49.433Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b1/d111b1df656761f980d9e298a60039a9cb66036b1d039e777537743d0ac3/onnxruntime-1.26.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05b028781b322ad74b57ce5b50aa5280bb1fe96ceec334628ade681e0b24c1ac", size = 18016624, upload-time = "2026-05-12T00:41:01.735Z" },
     { url = "https://files.pythonhosted.org/packages/f6/a0/3f9d896a0385a36bd04345d6d0b802821a5782adde562e7e135f6bb71c73/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:91f2bb870a4b9224eba0a6728c1fa7a9e552b8e59e1083c51fbbc3d013f2b5c0", size = 16052692, upload-time = "2026-05-08T19:07:13.829Z" },
     { url = "https://files.pythonhosted.org/packages/7c/43/2a4e04f8dbeffad19bbcced4bcd4289bf478921518437404d6b92bdf213b/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b6dd70599005bd1bf29779f04a91978b92b5e719c11a20068a8f8e535f725b6", size = 18185439, upload-time = "2026-05-08T19:07:36.299Z" },
     { url = "https://files.pythonhosted.org/packages/44/fc/026d0a7162b9c2153dac292baea9e027c42304dc1d9dc6f8ff5b4cfbaedd/onnxruntime-1.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:a26374dc7fbcaae593601086b242120e13f2310558df0991da6dd8b8fac00414", size = 13026427, upload-time = "2026-05-08T19:08:03.503Z" },
@@ -1529,6 +1543,93 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/e1/748f5663efe6edcfc4e74b2b93edfb9b8b99b67f21a854c3ae416500a2d9/pillow-12.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8be29e59487a79f173507c30ddf57e733a357f67881430449bb32614075a40ab", size = 5354347, upload-time = "2026-04-01T14:42:44.255Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a1/d5ff69e747374c33a3b53b9f98cca7889fce1fd03d79cdc4e1bccc6c5a87/pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71cde9a1e1551df7d34a25462fc60325e8a11a82cc2e2f54578e5e9a1e153d65", size = 4695873, upload-time = "2026-04-01T14:42:46.452Z" },
+    { url = "https://files.pythonhosted.org/packages/df/21/e3fbdf54408a973c7f7f89a23b2cb97a7ef30c61ab4142af31eee6aebc88/pillow-12.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f490f9368b6fc026f021db16d7ec2fbf7d89e2edb42e8ec09d2c60505f5729c7", size = 6280168, upload-time = "2026-04-01T14:42:49.228Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e", size = 8088188, upload-time = "2026-04-01T14:42:51.735Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/220a5994ef1b10e70e85748b75649d77d506499352be135a4989c957b701/pillow-12.2.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3997232e10d2920a68d25191392e3a4487d8183039e1c74c2297f00ed1c50705", size = 6394401, upload-time = "2026-04-01T14:42:54.343Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176", size = 7079655, upload-time = "2026-04-01T14:42:56.954Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3d/45132c57d5fb4b5744567c3817026480ac7fc3ce5d4c47902bc0e7f6f853/pillow-12.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:56a3f9c60a13133a98ecff6197af34d7824de9b7b38c3654861a725c970c197b", size = 6503105, upload-time = "2026-04-01T14:42:59.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/2e/9df2fc1e82097b1df3dce58dc43286aa01068e918c07574711fcc53e6fb4/pillow-12.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e6f81de50ad6b534cab6e5aef77ff6e37722b2f5d908686f4a5c9eba17a909", size = 7203402, upload-time = "2026-04-01T14:43:02.664Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2e/2941e42858ebb67e50ae741473de81c2984e6eff7b397017623c676e2e8d/pillow-12.2.0-cp311-cp311-win32.whl", hash = "sha256:8c984051042858021a54926eb597d6ee3012393ce9c181814115df4c60b9a808", size = 6378149, upload-time = "2026-04-01T14:43:05.274Z" },
+    { url = "https://files.pythonhosted.org/packages/69/42/836b6f3cd7f3e5fa10a1f1a5420447c17966044c8fbf589cc0452d5502db/pillow-12.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6e6b2a0c538fc200b38ff9eb6628228b77908c319a005815f2dde585a0664b60", size = 7082626, upload-time = "2026-04-01T14:43:08.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/88/549194b5d6f1f494b485e493edc6693c0a16f4ada488e5bd974ed1f42fad/pillow-12.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:9a8a34cc89c67a65ea7437ce257cea81a9dad65b29805f3ecee8c8fe8ff25ffe", size = 2463531, upload-time = "2026-04-01T14:43:10.743Z" },
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b7/2437044fb910f499610356d1352e3423753c98e34f915252aafecc64889f/pillow-12.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538bd5e05efec03ae613fd89c4ce0368ecd2ba239cc25b9f9be7ed426b0af1f", size = 5273969, upload-time = "2026-04-01T14:45:55.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f4/8316e31de11b780f4ac08ef3654a75555e624a98db1056ecb2122d008d5a/pillow-12.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:394167b21da716608eac917c60aa9b969421b5dcbbe02ae7f013e7b85811c69d", size = 4659674, upload-time = "2026-04-01T14:45:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/37/664fca7201f8bb2aa1d20e2c3d5564a62e6ae5111741966c8319ca802361/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d04bfa02cc2d23b497d1e90a0f927070043f6cbf303e738300532379a4b4e0f", size = 5288479, upload-time = "2026-04-01T14:46:01.141Z" },
+    { url = "https://files.pythonhosted.org/packages/49/62/5b0ed78fce87346be7a5cfcfaaad91f6a1f98c26f86bdbafa2066c647ef6/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0c838a5125cee37e68edec915651521191cef1e6aa336b855f495766e77a366e", size = 7032230, upload-time = "2026-04-01T14:46:03.874Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
 ]
 
 [[package]]
@@ -1868,6 +1969,52 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pytauri"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "importlib-metadata" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/4b/5dfba4c317436b5882e5446e66504cb6d06594f338ff9cced3ace9b71aa1/pytauri-0.8.0.tar.gz", hash = "sha256:e172f08c6afd46b8b772f951082456356cfb6e3b192379d9557ede9699ac24c2", size = 40400, upload-time = "2025-09-01T09:25:16.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/15/2679cf676f1c621a9decbf79abfa33891b9d7882d9bcd24751b5e554a095/pytauri-0.8.0-py3-none-any.whl", hash = "sha256:e7dc9b21f5ecf081b1e2751abf788792c8804cb3b2637de2b2d0b11a04794174", size = 62559, upload-time = "2025-09-01T09:25:15.428Z" },
+]
+
+[[package]]
+name = "pytauri-wheel"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytauri" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/97/62da6b7554598e9df2a06472e3035696ba7e96b492b595818c1028be6b26/pytauri_wheel-0.8.0.tar.gz", hash = "sha256:499825e6c0b06d819ded8f826d31aa15084373762180a6b9faa65aa762df4f98", size = 71178, upload-time = "2025-09-02T12:52:56.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/16/7de8f5e897c76ba0c6f35b5f726921527f88cb739d475786747539b7f9ba/pytauri_wheel-0.8.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:d6f09e7acc1116baf4d33033c1c0ce715adbace1ad88c3c460ec875521ff0b33", size = 10441985, upload-time = "2025-09-02T12:52:06.33Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/88/c8bbdefe82cda7369fc3805bb45c168f25c00139990321de02bdaaf8ccf2/pytauri_wheel-0.8.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:409e55c10e360f7f6d40041512a553de085045378a04de4c2bf513be5396e629", size = 10092825, upload-time = "2025-09-02T12:52:09.352Z" },
+    { url = "https://files.pythonhosted.org/packages/09/bb/a5761356cd98ddd09ab9ba315ab5563600c3ce35cb3950edcd0d4657511d/pytauri_wheel-0.8.0-cp311-cp311-manylinux_2_35_aarch64.whl", hash = "sha256:10767d2a146bd546484635518f494460eaf772c0d4cd402bef911695ad989a95", size = 12561482, upload-time = "2025-09-02T12:52:11.575Z" },
+    { url = "https://files.pythonhosted.org/packages/78/68/9d9d7503e835de43bfdcffad170bb95d9359001ccf1a20593bfdd4fe8c79/pytauri_wheel-0.8.0-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:38a18b2272f53fcb39fdd0a13949791f5f6980fb2cabcfe9cbf1385470c5fac7", size = 12699062, upload-time = "2025-09-02T12:52:13.592Z" },
+    { url = "https://files.pythonhosted.org/packages/18/83/2083d75fb30e6e1940dbbe4779e352b4c08a8f17917a94323a218676d299/pytauri_wheel-0.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:b3bbcd569715f0928c529aa9bf128096717c51a671a9ac6ad3d0334c45d26040", size = 9261708, upload-time = "2025-09-02T12:52:15.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/636579372d87352619035db36842e601c4e0e6e2dc707cd39360e9d4e8c7/pytauri_wheel-0.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:f7a09d568caa63e4dc1ad16c4a8fa29c039fa2063f822a7695ee53e857047162", size = 8684169, upload-time = "2025-09-02T12:52:19.53Z" },
+    { url = "https://files.pythonhosted.org/packages/05/cb/6624a3fedd625580d65bc7925b30d0cf5fc707eb75af8d0dcf7a6ae12a60/pytauri_wheel-0.8.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:8216a34c2d387af5faa757a7951d7085e244190cc26aa792f49ec899a3212f92", size = 10409533, upload-time = "2025-09-02T12:52:21.339Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4e/89e7816c1da6189ccfb706aa955886449d978f498788f9b888c7ed265719/pytauri_wheel-0.8.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cb7e4f2cea10e6d93ab6d95217ec3dba9f73bee67b01c8e8a13abe4f1c7ca085", size = 10061451, upload-time = "2025-09-02T12:52:23.241Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b6/79b23acfce2b0568da6a739fb249135fabe3ac69d6ce3228022232d8c008/pytauri_wheel-0.8.0-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:839ecb31ac3f75024d362e5a26bb915f29d1113d1f2da349884fe571f0b74bf4", size = 12546428, upload-time = "2025-09-02T12:52:25.167Z" },
+    { url = "https://files.pythonhosted.org/packages/02/55/83c784be4e8ee39b5e7ef8713a8fda0ef7ba97e75f904ec5ea73f5f1a42a/pytauri_wheel-0.8.0-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:4c45700adbc1a5e17f4b90d189156446f08c2a644fa5703a5504c1660d9609c0", size = 12702299, upload-time = "2025-09-02T12:52:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d2/68f43b6878d31e537f9e1ba44db724feeacea587353c1250cacefd79f994/pytauri_wheel-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:d72099c4996a4f07ec7332b4936b9d7b812406900fd0a1ea05056941ce193f6c", size = 9274857, upload-time = "2025-09-02T12:52:29.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b4/5048d0c31bf3a5eb8cbab6963f7c969c88890286cccedcd586f81724e430/pytauri_wheel-0.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:5c96a33c0741a632e02f7d15d47123919bb9ee223ebbb88971bb80d209a10cc6", size = 8685095, upload-time = "2025-09-02T12:52:31.675Z" },
+    { url = "https://files.pythonhosted.org/packages/06/5e/298a578c00af26468082e1b6282190dc080d9b4b7f4025cb168054af57fd/pytauri_wheel-0.8.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:5c1b96352b7750e594b616dd1a3ae89a93374aac14e6826b17070b39497c7dfc", size = 10409836, upload-time = "2025-09-02T12:52:34.001Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9a/65da5a3e8717b09032997cf772090ea419c0b1bf6cc496b83925588d98a7/pytauri_wheel-0.8.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e5b7d77e00971a1af4ccb4e79ba9c3bc5cc5622136f3fe589aa227ab5b053a32", size = 10061354, upload-time = "2025-09-02T12:52:35.91Z" },
+    { url = "https://files.pythonhosted.org/packages/87/13/bc1a631729fb6b3543d4f2c520594de24feeeb4a4fb1bf3825f888471ce3/pytauri_wheel-0.8.0-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:6d49ab4919e33f90f0dfd9d2b2a946f741a9e3e9c5c9fdd6aafb5b9a640dcde9", size = 12547637, upload-time = "2025-09-02T12:52:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/87/71813121214a2032961d43a28b633ebdabc096ba04b072dc42c60985744c/pytauri_wheel-0.8.0-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:8478b45cd68eb2a9ea65d3ef044f584827738222a969c34819e8c823da6c8052", size = 12702400, upload-time = "2025-09-02T12:52:39.962Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/70/c55cc392c45304c3ed47ef5431ce064c6c975b105e2be0ccf0f303ba2982/pytauri_wheel-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:6bc2007f8f32d97f41d37b0c753636f2d8e6de7c7153b6b2c3a296c7725b9d6a", size = 9274557, upload-time = "2025-09-02T12:52:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/78/5396e01a0180d14cb052dbbe4ef6f76fab1ce7a62dd6d04e9c5fd63e7026/pytauri_wheel-0.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:210ae1bb276f1205ea32a20e9fae2effe845f4b98bc0ce7418512d1d81eb8ffd", size = 8684901, upload-time = "2025-09-02T12:52:43.763Z" },
 ]
 
 [[package]]

--- a/website_oper/finding_jobs.py
+++ b/website_oper/finding_jobs.py
@@ -76,6 +76,29 @@ async def _wait_url_stable(stable_for: float = 2.0, timeout: float = 30) -> str:
 # ---------- 浏览器生命周期 ----------
 
 
+async def shutdown() -> None:
+    """关 Chrome 并清空模块级 ``_browser`` / ``_tab``。
+
+    给 GUI 用——用户点"重置"想从头来一遍时调一次，否则下次
+    ``open_browser_with_options`` 会留旧 Chrome 进程。CLI 不需要：``main.py``
+    退出时 OS 会清理子进程。
+
+    ``Browser.stop()`` 是同步函数，但本函数声明 ``async`` 是为了让 GUI
+    runner 能 ``await shutdown()``（runner 一律 await，sync/async 不混用）。
+
+    重启注意：这只关 Chrome 进程；nodriver 跟 uvloop 的重启不兼容问题需要
+    GUI 入口传 ``loop="asyncio"`` 才能彻底解决（见 project memory）。
+    """
+    global _browser, _tab
+    if _browser is not None:
+        try:
+            _browser.stop()
+        except Exception as e:
+            log.warning("browser.stop() 失败（不致命）: %s", e)
+    _browser = None
+    _tab = None
+
+
 async def open_browser_with_options(url: str, browser: str) -> None:
     """启动 Chrome 并打开 url。``browser`` 仅接受 ``"chrome"``。"""
     global _browser, _tab

--- a/website_oper/write_response.py
+++ b/website_oper/write_response.py
@@ -28,6 +28,7 @@ import time
 
 from audit import log_attempt, validate_letter
 from audit.telemetry import record_llm_call
+from gui.events import emit as _emit_progress
 from models.job_matcher import should_apply
 from models.llm import PROVIDERS, generate_letter
 from website_oper import finding_jobs
@@ -195,7 +196,9 @@ async def send_job_descriptions_to_chat(
     会进入半死状态，下次 evaluate 直接 hang。详见模块 docstring。
     """
     await finding_jobs.open_browser_with_options(url, browser_type)
+    _emit_progress("browser_started")
     await finding_jobs.log_in()
+    _emit_progress("login_ok")
 
     job_index = 1
     iteration = 0
@@ -211,6 +214,7 @@ async def send_job_descriptions_to_chat(
             job_description = await finding_jobs.get_job_description_by_index(job_index)
             if job_description:
                 consecutive_misses = 0
+                _emit_progress("job_found", index=job_index, jd_preview=job_description[:80])
                 element = await finding_jobs.get_text_by_css(".op-btn.op-btn-chat")
                 log.info("chat 按钮文字: %r", element)
                 if element == "立即沟通":
@@ -233,11 +237,17 @@ async def send_job_descriptions_to_chat(
                                     "⏭️ [跳过 #%d] LLM 评分 %s/%s: %s",
                                     job_index, details["score"], details["threshold"], details["reason"],
                                 )
+                            _emit_progress(
+                                "job_skipped",
+                                index=job_index,
+                                reason=stage,
+                                detail=details.get("reason", ""),
+                            )
                             job_index += 1
                             await asyncio.sleep(3)
                             continue
                         log.info("✅ [匹配 #%d] 关键词命中: %s", job_index, details["matched_keywords"])
-                        if details.get("score"):
+                        if "score" in details:
                             log.info("   LLM 评分: %s/100 - %s", details["score"], details["reason"])
                     # ====== 过滤结束 ======
 
@@ -270,6 +280,7 @@ async def send_job_descriptions_to_chat(
                             job_description=job_description, letter=response,
                             validation=validation, dry_run=dry_run, sent=False,
                         )
+                        _emit_progress("letter_sent", index=job_index, status="blocked")
                     elif dry_run:
                         log.info(
                             "[DRY-RUN] 招呼语 (%d 字符) 不发送。--- letter ---\n%s\n--------------",
@@ -280,6 +291,7 @@ async def send_job_descriptions_to_chat(
                             job_description=job_description, letter=response,
                             validation=validation, dry_run=True, sent=False,
                         )
+                        _emit_progress("letter_sent", index=job_index, status="dry_run")
                     else:
                         log.info("发送招呼语：%s", response)
                         await asyncio.sleep(1)
@@ -294,6 +306,7 @@ async def send_job_descriptions_to_chat(
                             job_description=job_description, letter=response,
                             validation=validation, dry_run=False, sent=True,
                         )
+                        _emit_progress("letter_sent", index=job_index, status="sent")
             else:
                 consecutive_misses += 1
                 log.info(
@@ -305,6 +318,7 @@ async def send_job_descriptions_to_chat(
                         "连续 %d 个岗位拿不到，推测已到推荐 feed 列表底部，结束",
                         MAX_CONSECUTIVE_MISSES,
                     )
+                    _emit_progress("feed_exhausted", total=job_index - 1)
                     break
 
             await asyncio.sleep(3)
@@ -312,4 +326,9 @@ async def send_job_descriptions_to_chat(
 
         except Exception as e:
             log.exception("主循环抛异常: %s", e)
+            _emit_progress(
+                "error",
+                stage=f"job_index={job_index}",
+                message=f"{type(e).__name__}: {e}",
+            )
             break


### PR DESCRIPTION
## Summary

给 BOSS 脚本加一个本地桌面 App（PyTauri + React/TS + Tailwind），跟 CLI (`main.py`) 平行共存，**CLI 行为字节级零变化**。

目前是 **dev 模式可用版本**：`uv sync --extra tauri && cd tauri-ui && pnpm install && pnpm build && cd .. && uv run python -m boss_tauri` 双击式开发体验已经能给 Python 朋友试用。

**Phase D（standalone .app bundle）单独开 session 做**——发现需要前置把 BOSS 重构成可安装 package（当前 `package = false`，pytauri standalone 装不进去），那个改动量值得独立 PR。详细分析见 plan 文件 / `project-pytauri-capabilities` memory。

## 设计核心

- **CLI 完全不动**。`gui.events.emit()` 在 callback=None（CLI 模式）时是 no-op，业务代码 byte-identical 行为不变。
- **不在 CLI 链路引入 pytauri 依赖**。`gui/` 包只用 stdlib + pydantic（已是项目主 dep）。pytauri 通过 `[project.optional-dependencies] tauri` 独立管理。
- **Tauri ACL**：`boss_tauri/capabilities/default.toml` 显式 grant `pytauri:default`，否则前端 pyInvoke 全部被拦（Tauri 2.x default-deny）。
- **asyncio loop 不用 uvloop**：`start_blocking_portal("asyncio")` 显式锁定。uvloop 跟 nodriver 的 Chrome stop+restart 不兼容，已经用探针验证过。

## 7 个 commit

1. `feat(job_matcher)`: BOSS_MIN_MATCH_SCORE env var
2. `docs`: 2026-05-13 CDP hang postmortem
3. `feat(gui)`: 进度事件总线 + 可取消 runner + 日志桥（13 个新单测）
4. `feat`: 主循环 emit + Chrome shutdown helper（业务侧 6 处 emit）
5. `feat(boss_tauri)`: PyTauri Python 入口 + 9 个 IPC commands
6. `feat(tauri-ui)`: React + TS + Tailwind 三 tab 前端
7. `ci+chore`: smoke imports + gitignore tauri 产物 + resume PDFs

## Test plan

- [x] `uv run pytest tests/` 全过（87 passed）
- [x] CLI smoke import（CI ci.yml 里那 N 行）全过
- [x] 加 `--extra tauri` 后 `from boss_tauri import commands` OK
- [x] `uv run python -m boss_tauri` 启动稳定 ≥ 7 秒，UI 弹出
- [x] PyTauri × nodriver 探针手动点按钮验证 PASS（含 stop+restart）
- [ ] **DRY_RUN=1 uv run main.py** CLI 模式行为字节级不变（PR review 时本地跑一遍）
- [ ] **GUI 端 dry-run 完整跑一次**（PR review 时点开始 → 看进度流 → 停止 → 重启不留孤儿 Chrome）

## 后续

- Phase D（standalone .app bundle）：另开 PR，前置把 BOSS 重构为可安装 package
- Windows 构建：等 macOS 路径走通后再考虑
- macOS notarization：发布前再处理（需 Apple Developer $99/年）