### PR TITLE
feat: Windows standalone 打包 + GUI 两个 hang/误判修复

### DIFF
--- a/docs/wiki/adr/005-pytauri-standalone.md
+++ b/docs/wiki/adr/005-pytauri-standalone.md
@@ -45,7 +45,7 @@
 
 两份 capabilities / 四处版本号靠 `tests/test_standalone_sync.py` 守卫。
 
-## 构建：只能走 `scripts/build_standalone.sh`
+## 构建：只能走 `scripts/build_standalone.{sh,ps1}`
 
 **不要手工跑其中某几步。** 2026-06-07 的第一次手工构建漏了
 `PYO3_PYTHON` + `RUSTFLAGS`，pyo3 自动探测到系统 CLT 的
@@ -63,6 +63,31 @@
 5. `tauri build --config src-tauri/tauri.bundle.json -- --profile bundle-release`
    （独立 profile，不污染 `tauri dev` 的 target/release；bundle resources
    把 `pyembed/python` 整个拷进 .app 的 Resources/）
+
+### Windows standalone（`scripts/build_standalone.ps1`）
+
+跟 macOS 平行的 PowerShell 脚本。前置：Visual Studio Build Tools（含
+"Desktop development with C++" workload，给 MSVC 链接器）/ uv / pnpm。
+
+与 `.sh` 的关键差异：
+
+| 步骤 | macOS | Windows |
+|---|---|---|
+| 嵌入 Python 布局 | `python/bin/python3` + `lib/libpython3.X.dylib` | `python\python.exe` + `python\python313.dll` + `python\libs\python313.lib` |
+| libpython rpath 补丁 | `install_name_tool -id @rpath/...` | **不需要**——PE 加载器同目录优先 |
+| `RUSTFLAGS` rpath | `-Wl,-rpath,@executable_path/../Resources/lib` | **不需要** |
+| `RUSTFLAGS` 链接路径 | `-L pyembed/python/lib`（libpython 给 pyo3 链） | `-L native=pyembed\python\libs`（python313.lib 给 pyo3 链） |
+| Bundle target | `.app` + `.dmg` | NSIS `*-setup.exe` + MSI `*.msi`（看 tauri.conf.json） |
+| 自检 | `otool -L` 看没链 `Python3.framework` | PE IMPORTS 只记 DLL 文件名不记路径，自检退化成"找产物 + 列安装器"；真正的链对/链错要等装一遍 installer，开 Process Explorer 看加载的 `python313.dll` 路径 |
+
+风险点（暂未实测，标 TODO）：
+
+- `tauri.bundle.json` 的 `"pyembed/python": "./"` 在 Windows 的 NSIS/MSI 里
+  把 `python313.dll` 放在跟 `boss-zhipin.exe` 同级——这是 DLL 同目录优先
+  解析能命中的位置。如果改成放 `resources/` 子目录，启动会找不到 DLL。
+- `RUSTFLAGS` 按 whitespace 切，路径里有空格（``C:\Program Files\...``）
+  会炸。本仓库默认在无空格盘下（`E:\BossZhiPin_Job_Search`），不预先优化；
+  以后真踩到再换 `CARGO_ENCODED_RUSTFLAGS`。
 
 ## 体积
 

--- a/scripts/build_standalone.ps1
+++ b/scripts/build_standalone.ps1
@@ -1,0 +1,153 @@
+﻿# Phase D：Windows 上打 standalone .exe / NSIS / MSI（macOS .app 的等价物）。
+#
+# 跟 build_standalone.sh 平行——固化"嵌入式 Python 组装 + 业务包安装 +
+# Rust 链接参数 + tauri bundle"整条流程。**不要手工拆步骤跑**：漏掉
+# PYO3_PYTHON / RUSTFLAGS 会让 pyo3 自动探测到系统 Python，bundle 后启动
+# 直接 LoadLibrary 失败（参考 macOS 同样的坑，见 ADR-005）。
+#
+# 用法（PowerShell）：
+#   .\scripts\build_standalone.ps1
+#   $env:BOSS_PYEMBED_REBUILD = '1'; .\scripts\build_standalone.ps1   # 强制重建 pyembed
+#
+# 产物：
+#   src-tauri\target\bundle-release\boss-zhipin.exe                  （raw exe）
+#   src-tauri\target\bundle-release\bundle\nsis\*-setup.exe          （NSIS 安装器）
+#   src-tauri\target\bundle-release\bundle\msi\*.msi                 （MSI 安装器）
+#
+# 前置：
+#   - Visual Studio Build Tools（含 "Desktop development with C++" workload）
+#   - uv（用于装嵌入式 Python + 业务包）
+#   - pnpm（前端构建）
+#   - 不需要 install_name_tool / otool：Windows PE 解析 DLL 是同目录优先，
+#     bundle 后 python313.dll 跟 boss-zhipin.exe 同级即可
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+Set-Location $RepoRoot
+
+$PyembedDir   = Join-Path $RepoRoot 'src-tauri\pyembed'
+$PythonSeries = '3.13'   # 跟 pyproject requires-python 对齐
+$EmbedPy      = Join-Path $PyembedDir 'python\python.exe'
+
+# ---------- 0. 前置工具链检查 ----------
+# Cargo.lock 在 mac 端用 Cargo >=1.78 生成（lockfile v4），低版本直接
+# "lock file version 4 ... does not understand"。在 step 5 才炸太晚——
+# 已经花了几十分钟拉 torch 和编前端，这里 fail-fast。
+$CargoVersionLine = (& cargo --version) 2>$null
+if ($LASTEXITCODE -ne 0 -or -not $CargoVersionLine) {
+    throw "找不到 cargo——装 Visual Studio Build Tools + rustup 之后重跑"
+}
+if ($CargoVersionLine -match 'cargo (\d+)\.(\d+)') {
+    $major = [int]$Matches[1]; $minor = [int]$Matches[2]
+    if ($major -lt 1 -or ($major -eq 1 -and $minor -lt 78)) {
+        throw "Cargo $major.$minor 太老（需要 >=1.78 解析 Cargo.lock v4），跑 ``rustup update stable``"
+    }
+}
+
+# ---------- 1. 嵌入式 Python（python-build-standalone，经 uv 下载） ----------
+if ($env:BOSS_PYEMBED_REBUILD -eq '1') {
+    if (Test-Path $PyembedDir) {
+        Write-Host "==> BOSS_PYEMBED_REBUILD=1，清空 $PyembedDir"
+        Remove-Item -Recurse -Force $PyembedDir
+    }
+}
+
+if (-not (Test-Path $EmbedPy)) {
+    Write-Host "==> 下载嵌入式 Python $PythonSeries（python-build-standalone）"
+    New-Item -ItemType Directory -Path $PyembedDir -Force | Out-Null
+    $DownloadDir = Join-Path $PyembedDir '_download'
+    $env:UV_PYTHON_INSTALL_DIR = $DownloadDir
+    try {
+        uv python install $PythonSeries
+        if ($LASTEXITCODE -ne 0) { throw "uv python install 失败（exit $LASTEXITCODE）" }
+        # uv 落盘目录名带完整版本号（cpython-3.13.x-x86_64-pc-windows-msvc-shared），
+        # 规范成 python/ 让后续路径稳定
+        $SrcDir = Get-ChildItem -Path $DownloadDir -Directory -Filter 'cpython-*' |
+                  Select-Object -First 1
+        if (-not $SrcDir) { throw "没找到 uv 下载的 cpython 目录" }
+        Move-Item -Path $SrcDir.FullName -Destination (Join-Path $PyembedDir 'python')
+        Remove-Item -Recurse -Force $DownloadDir
+    } finally {
+        Remove-Item Env:UV_PYTHON_INSTALL_DIR -ErrorAction SilentlyContinue
+    }
+}
+
+$PyVersion = & $EmbedPy --version
+if ($LASTEXITCODE -ne 0) { throw "嵌入式 python.exe 跑不起来：$EmbedPy" }
+Write-Host "==> 嵌入式 Python: $PyVersion"
+
+# ---------- 2. macOS：libpython install_name 打 @rpath 补丁 ----------
+# Windows 不需要。PE 加载器优先在 exe 同目录找 DLL，pyembed 的 python313.dll
+# 在 bundle 里跟 boss-zhipin.exe 拷一起就行（见 tauri.bundle.json resources）。
+
+# ---------- 3. 把业务包 + 依赖装进嵌入式环境 ----------
+# --break-system-packages：uv 把自己装的 python-build-standalone 标成 PEP 668
+# "externally managed"，默认拒绝 pip 写入。本场景就是要往里写，加 flag 放行。
+# （macOS 的 .sh 没踩到大概是早期 uv 没强制，新版 uv 两边都会拦。）
+Write-Host "==> 安装 boss_zhipin + 依赖到 pyembed（首次会拉 torch，较慢）"
+$env:PYTAURI_STANDALONE = '1'
+uv pip install --exact --compile-bytecode --break-system-packages `
+    "--python=$EmbedPy" `
+    --reinstall-package=boss-zhipin-job-search `
+    "$RepoRoot[standalone]"
+if ($LASTEXITCODE -ne 0) { throw "uv pip install 失败（exit $LASTEXITCODE）" }
+
+# ---------- 4. Rust 链接参数 ----------
+# PYO3_PYTHON：不设的话 pyo3 自动探测系统 Python → 链到 PATH 上的 python.exe
+# 或注册表里的 Python → bundle 后启动 LoadLibrary 拿错版本。
+# RUSTFLAGS -L：python313.lib 在 python-build-standalone 的 libs/ 子目录下，
+# 给 pyo3 链接期找 import library 用。
+$env:PYO3_PYTHON = $EmbedPy
+$PythonLibs = Join-Path $PyembedDir 'python\libs'
+if (-not (Test-Path $PythonLibs)) {
+    throw "$PythonLibs 不存在——python-build-standalone 该带 libs/python313.lib 给 pyo3 链"
+}
+# 注意：RUSTFLAGS 按 whitespace 切，路径里如果有空格会炸。本仓库默认装 E:\
+# 下没空格，没空格就别提前优化；以后真踩到再用 CARGO_ENCODED_RUSTFLAGS。
+$env:RUSTFLAGS = "-L native=$PythonLibs"
+
+# ---------- 5. 前端 + tauri bundle ----------
+Write-Host "==> pnpm install（tauri-ui）"
+$TauriUiDir = Join-Path $RepoRoot 'tauri-ui'
+pnpm --dir $TauriUiDir install --frozen-lockfile
+if ($LASTEXITCODE -ne 0) { throw "pnpm install 失败（exit $LASTEXITCODE）" }
+
+Write-Host "==> tauri build（bundle-release profile）"
+# --config tauri.bundle.json：把 pyembed/python 作为 resources 打进 bundle；
+# 必须从 repo root 跑——tauri CLI 只往**子目录**找 src-tauri/tauri.conf.json。
+$TauriBin = Join-Path $TauriUiDir 'node_modules\.bin\tauri.cmd'
+if (-not (Test-Path $TauriBin)) { throw "tauri CLI 没装：$TauriBin（pnpm install 失败？）" }
+& $TauriBin build `
+    --config (Join-Path $RepoRoot 'src-tauri\tauri.bundle.json') `
+    -- --profile bundle-release
+if ($LASTEXITCODE -ne 0) { throw "tauri build 失败（exit $LASTEXITCODE）" }
+
+# ---------- 6. 产物自检 ----------
+$TargetRoot = Join-Path $RepoRoot 'src-tauri\target'
+$ExeMatches = Get-ChildItem -Path $TargetRoot -Recurse -Filter 'boss-zhipin.exe' `
+    -ErrorAction SilentlyContinue |
+    Where-Object { $_.FullName -match 'bundle-release' }
+if (-not $ExeMatches) { throw "没找到 boss-zhipin.exe 产物——cargo build 没成？" }
+$Exe = $ExeMatches[0].FullName
+Write-Host "==> raw exe: $Exe"
+
+# bundle installer 列举：NSIS / MSI 看 tauri.conf.json bundle targets
+$Bundles = Get-ChildItem -Path $TargetRoot -Recurse `
+    -Include '*.msi', '*-setup.exe' -ErrorAction SilentlyContinue |
+    Where-Object { $_.FullName -match 'bundle-release' }
+if ($Bundles) {
+    foreach ($b in $Bundles) {
+        Write-Host "[OK] 安装器：$($b.FullName)"
+    }
+} else {
+    Write-Warning "没生成 NSIS/MSI 安装器，检查 tauri.conf.json 的 bundle.targets"
+    Write-Host  "（raw exe 已生成，但 python313.dll 等 resources 只在 installer 里拷齐）"
+}
+
+# 提醒：dumpbin 检查 IMPORTS 是 nice-to-have，但 import 只记 DLL 文件名
+# （python313.dll），不记路径——能不能链对靠 bundle 后跟 DLL 同目录。
+# 装一遍 installer，开 .exe，看 Process Explorer 里加载的 python313.dll 路径
+# 是不是装目录下那份。
+Write-Host "[OK] 构建完成"

--- a/scripts/build_standalone.sh
+++ b/scripts/build_standalone.sh
@@ -21,6 +21,18 @@ PYTHON_SERIES="3.13"   # 跟 pyproject requires-python 对齐
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "❌ 目前只支持 macOS（Linux/Windows 的 rpath / install_name 处理不同）"
+    echo "   Windows 端用 scripts/build_standalone.ps1"
+    exit 1
+fi
+
+# Cargo.lock v4 需要 Cargo >=1.78，老版本在 step 5 才炸太晚
+cargo_ver=$(cargo --version 2>/dev/null | sed -n 's/cargo \([0-9]*\)\.\([0-9]*\).*/\1.\2/p')
+if [[ -z "$cargo_ver" ]]; then
+    echo "❌ 找不到 cargo，请先装 rustup"; exit 1
+fi
+cargo_major=${cargo_ver%.*}; cargo_minor=${cargo_ver#*.}
+if (( cargo_major < 1 || (cargo_major == 1 && cargo_minor < 78) )); then
+    echo "❌ Cargo $cargo_ver 太老（需 >=1.78 解析 lockfile v4），跑 'rustup update stable'"
     exit 1
 fi
 
@@ -52,10 +64,14 @@ echo "==> libpython install_name 已设为 @rpath/$(basename "$libpython")"
 # ---------- 3. 把业务包 + 依赖装进嵌入式环境 ----------
 # [standalone] extra：pytauri 但不带 pytauri-wheel（ext_mod 由我们的 Rust
 # binary 提供）。--exact 保证环境里只有声明过的东西。
+# --break-system-packages：uv 把 python-build-standalone 标 PEP 668
+# "externally managed"，默认拒绝 pip 写入；本场景就是要往里写，加 flag 放行。
+# （2026-06-07 在 Windows 端 .ps1 上踩到，mac 上当时 uv 版本旧没拦，新 uv 两边都会拦。）
 echo "==> 安装 boss_zhipin + 依赖到 pyembed（首次会拉 torch，较慢）"
 PYTAURI_STANDALONE=1 uv pip install \
     --exact \
     --compile-bytecode \
+    --break-system-packages \
     --python="$EMBED_PY" \
     --reinstall-package=boss-zhipin-job-search \
     "$REPO_ROOT[standalone]"

--- a/src/boss_zhipin/tauri/__init__.py
+++ b/src/boss_zhipin/tauri/__init__.py
@@ -197,29 +197,23 @@ async def shutdown_browser() -> dict[str, str]:
 # ---------- Config 面板 ----------
 
 
-class EnvField(_CamelModel):
-    key: str
-    label: str
-    is_secret: bool
-    value: str
-
-
 @commands.command()
-async def get_env_fields() -> dict[str, list[EnvField]]:
-    """返回前端 Config 表单的所有字段 + 当前值。"""
+async def get_env_fields() -> dict[str, list[dict]]:
+    """返回前端 Config 表单的所有字段 + 当前值。
+
+    返回 plain dict 列表，不要塞 pydantic BaseModel 实例——pytauri 的 IPC
+    response 走 JSON 序列化，遇到未 ``model_dump`` 的 BaseModel 会卡住
+    （promise 不 resolve 也不 reject），前端 Config 页一直显示"加载中…"。
+    """
     from boss_zhipin.gui.env_io import field_meta, read_env
 
     current = read_env()
-    fields = [
-        EnvField(
-            key=meta["key"],  # type: ignore[arg-type]
-            label=meta["label"],  # type: ignore[arg-type]
-            is_secret=bool(meta["isSecret"]),
-            value=current.get(meta["key"], ""),  # type: ignore[arg-type]
-        )
-        for meta in field_meta()
-    ]
-    return {"fields": fields}
+    return {
+        "fields": [
+            {**meta, "value": current.get(str(meta["key"]), "")}
+            for meta in field_meta()
+        ]
+    }
 
 
 class WriteEnvBody(_CamelModel):

--- a/src/boss_zhipin/website_oper/finding_jobs.py
+++ b/src/boss_zhipin/website_oper/finding_jobs.py
@@ -50,10 +50,45 @@ def _on_login_page(url: str) -> bool:
 
 
 async def _is_logged_in() -> bool:
-    """登录态以 URL 为准：BOSS 未登录时一定 redirect 到 /web/user/ 类路径。"""
+    """判定登录态：URL + DOM 双 check。
+
+    早期 BOSS 对未登录用户一定 redirect 到 ``/web/user/`` 类路径，只看 URL 够用。
+    现在它经常**不 redirect**，而是直接在 ``/web/geek/...`` 原地盖一个登录浮层。
+    只看 URL 会把这种情况误判成已登录，后续 ``get_job_description`` 抓到的是
+    浮层背后的 ``<style>`` 噪音（关键词命中 0/2 → feed_exhausted 假阴性）。
+
+    所以加一层 DOM 探测：页面里有可见的登录浮层就强制判未登录。选不到浮层时
+    退回原 URL 判定，避免 BOSS 改 class 名后把真实已登录态误杀。
+    """
     if _tab is None:
         return False
-    return not _on_login_page(_tab.url)
+    # URL 命中已知登录页路径 → 直接未登录，连 DOM 都不用问
+    if _on_login_page(_tab.url):
+        return False
+
+    # BOSS 的登录浮层 class 名换过几版：boss-login-dialog / login-dialog-wrap /
+    # loginDialog 等，统一用 attribute selector 兜
+    js = """
+    JSON.stringify((() => {
+      const visible = (el) => {
+        if (!el) return false;
+        const cs = getComputedStyle(el);
+        if (cs.display === 'none' || cs.visibility === 'hidden') return false;
+        const r = el.getBoundingClientRect();
+        return r.width > 0 && r.height > 0;
+      };
+      const wall = document.querySelector(
+        '[class*="login-dialog"], [class*="boss-login"], '
+        + '[class*="loginDialog"], [class*="login-wrap"]'
+      );
+      return { loginWallVisible: visible(wall) };
+    })());
+    """
+    info = await _safe_evaluate(js, timeout=5)
+    if info.get("loginWallVisible"):
+        log.info("URL 看起来已登录但页面上有登录浮层 → 判未登录，走扫码")
+        return False
+    return True
 
 
 async def _wait_url_stable(stable_for: float = 2.0, timeout: float = 30) -> str:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -5,7 +5,16 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 from boss_zhipin import paths
+
+# Linux 分支用例会 ``monkeypatch.setattr(os, "name", "posix")``——
+# Python 3.13 起在 Windows 上禁止实例化 PosixPath，这两个用例在 Windows
+# 上必失败但行为正确，跳过即可（CI 的 Linux runner 仍会跑）。
+_skip_on_windows = pytest.mark.skipif(
+    os.name == "nt", reason="Linux 分支需要 PosixPath，Win 上 Python 3.13+ 禁止实例化"
+)
 
 
 class TestIsStandalone:
@@ -34,6 +43,7 @@ class TestAppDataDir:
         result = paths.app_data_dir()
         assert result == Path.home() / "Library" / "Application Support" / paths.APP_IDENTIFIER
 
+    @_skip_on_windows
     def test_linux_xdg_default(self, monkeypatch, tmp_path):
         monkeypatch.delenv("BOSS_APP_DATA_DIR", raising=False)
         monkeypatch.setattr(sys, "platform", "linux")
@@ -46,7 +56,7 @@ class TestAppDataDir:
         # 否则 .app 的数据目录跟 Tauri 自己（WebView cache 等）的不在一处
         import json
         conf = json.loads(
-            (Path(__file__).parent.parent / "src-tauri" / "tauri.conf.json").read_text()
+            (Path(__file__).parent.parent / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8")
         )
         assert paths.APP_IDENTIFIER == conf["identifier"]
 

--- a/tests/test_standalone_sync.py
+++ b/tests/test_standalone_sync.py
@@ -19,10 +19,10 @@ SRC_TAURI_DIR = REPO_ROOT / "src-tauri"
 
 def test_capabilities_in_sync():
     toml_cap = tomllib.loads(
-        (WHEEL_TAURI_DIR / "capabilities" / "default.toml").read_text()
+        (WHEEL_TAURI_DIR / "capabilities" / "default.toml").read_text(encoding="utf-8")
     )
     json_cap = json.loads(
-        (SRC_TAURI_DIR / "capabilities" / "default.json").read_text()
+        (SRC_TAURI_DIR / "capabilities" / "default.json").read_text(encoding="utf-8")
     )
     assert toml_cap["identifier"] == json_cap["identifier"]
     assert toml_cap["windows"] == json_cap["windows"]
@@ -32,10 +32,10 @@ def test_capabilities_in_sync():
 
 
 def test_versions_in_sync():
-    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
-    wheel_tauri = tomllib.loads((WHEEL_TAURI_DIR / "Tauri.toml").read_text())
-    tauri_conf = json.loads((SRC_TAURI_DIR / "tauri.conf.json").read_text())
-    cargo = tomllib.loads((SRC_TAURI_DIR / "Cargo.toml").read_text())
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    wheel_tauri = tomllib.loads((WHEEL_TAURI_DIR / "Tauri.toml").read_text(encoding="utf-8"))
+    tauri_conf = json.loads((SRC_TAURI_DIR / "tauri.conf.json").read_text(encoding="utf-8"))
+    cargo = tomllib.loads((SRC_TAURI_DIR / "Cargo.toml").read_text(encoding="utf-8"))
 
     version = pyproject["project"]["version"]
     assert wheel_tauri["version"] == version, "Tauri.toml 版本号没跟 pyproject 同步"
@@ -44,8 +44,8 @@ def test_versions_in_sync():
 
 
 def test_identifiers_in_sync():
-    tauri_conf = json.loads((SRC_TAURI_DIR / "tauri.conf.json").read_text())
-    wheel_tauri = tomllib.loads((WHEEL_TAURI_DIR / "Tauri.toml").read_text())
+    tauri_conf = json.loads((SRC_TAURI_DIR / "tauri.conf.json").read_text(encoding="utf-8"))
+    wheel_tauri = tomllib.loads((WHEEL_TAURI_DIR / "Tauri.toml").read_text(encoding="utf-8"))
     from boss_zhipin.paths import APP_IDENTIFIER
 
     assert tauri_conf["identifier"] == APP_IDENTIFIER
@@ -53,6 +53,6 @@ def test_identifiers_in_sync():
 
 
 def test_product_name_in_sync():
-    tauri_conf = json.loads((SRC_TAURI_DIR / "tauri.conf.json").read_text())
-    wheel_tauri = tomllib.loads((WHEEL_TAURI_DIR / "Tauri.toml").read_text())
+    tauri_conf = json.loads((SRC_TAURI_DIR / "tauri.conf.json").read_text(encoding="utf-8"))
+    wheel_tauri = tomllib.loads((WHEEL_TAURI_DIR / "Tauri.toml").read_text(encoding="utf-8"))
     assert tauri_conf["productName"] == wheel_tauri["productName"]


### PR DESCRIPTION
## Summary

三块互相独立的改动，因为都是这次 session 在 Windows 上一边跑桌面 App / 验证打包链路一边踩出来的，捏成一个 PR：

- **fix(gui)**：Config 页"加载中…"卡死 + 登录态 DOM 探测
- **feat(build)**：Windows standalone 打包脚本 `build_standalone.ps1` + `.sh` 同步 `--break-system-packages` + ADR-005 补 Windows 节
- **test**：让单测在 Windows 上能跑（UTF-8 + Linux 用例跳过）

## 1. Config 页 hang（`src/boss_zhipin/tauri/__init__.py`）

`get_env_fields` 之前返回 `dict[str, list[EnvField]]`，`EnvField` 是 pydantic `BaseModel`。pytauri 的 IPC response 走 JSON 序列化，遇到未 `model_dump` 的 `BaseModel` 不抛也不 resolve，前端 promise 永远挂着，Config 页一直显示"加载中…"（footer 文字仍然可见，正好对上现象）。

改成返回 plain dict 列表，删掉 `EnvField` 类。

## 2. 登录态 DOM 探测（`src/boss_zhipin/website_oper/finding_jobs.py`）

`_is_logged_in()` 此前只看 URL：BOSS 早期对未登录用户一定 redirect 到 `/web/user/`。现在 BOSS 经常**不 redirect**，直接在 `/web/geek/...` 原地盖一个登录浮层。URL 看着像已登录但实际是登录墙，后续 `get_job_description` 抓到的是浮层背后的 `<style>` 噪音（`[job_skipped] reason="keyword" 命中 0/2` → `feed_exhausted` 假阴性）。

新逻辑：
1. URL 命中 `/web/user/` / `passport-zp` / `/login` → 一定未登录
2. URL 正常但页面上有可见登录浮层（`[class*=login-dialog]` 等四种兜底）→ 强制未登录
3. 浮层选不到 → 退回 URL 判定，避免 BOSS 改 class 名后把真实已登录态误杀

## 3. Windows 打包脚本（`scripts/build_standalone.ps1`）

跟 `.sh` 平行的 PowerShell 版本，结构镜像 macOS 流程但去掉 macOS 专属步骤：

| 步骤 | macOS | Windows |
|---|---|---|
| Python 布局 | `python/bin/python3` + `lib/libpython.dylib` | `python\python.exe` + `python313.dll` + `libs\python313.lib` |
| install_name rpath 补丁 | `install_name_tool -id @rpath/...` | 不需要（PE 同目录优先解析 DLL） |
| RUSTFLAGS rpath | `-Wl,-rpath,@executable_path/../Resources/lib` | 不需要 |
| RUSTFLAGS 链路径 | `-L pyembed/python/lib` | `-L native=pyembed\python\libs` |
| Bundle target | `.app` + `.dmg` | NSIS `*-setup.exe` + MSI `*.msi` |
| 自检 | `otool -L` 看没链 Python3.framework | PE IMPORTS 不记路径，退化成"找产物 + 列安装器" |

脚本特意做了几处 Windows 容易踩的预防：
- UTF-8 BOM 头（PS 5.1 默认按系统 codepage 读脚本，中文注释会让字符串引号串行）
- Cargo `>=1.78` 前置检查（`Cargo.lock` v4，旧 cargo 在 step 5 才炸太晚）
- `--break-system-packages` flag（uv 把它自己装的 python-build-standalone 标 PEP 668 拒绝写 pip）

## 4. `.sh` 同步 + ADR-005

`.sh` 一并加了 `--break-system-packages`（新 uv 在 mac 上也会拦）+ Cargo 前置检查 + "Windows 端用 .ps1" 提示。

ADR-005 增加"Windows standalone"小节：macOS → Windows 步骤映射表、风险点（DLL 同目录解析、RUSTFLAGS 路径空格、bundle target 配置）。

## 5. 测试 portability

- `test_standalone_sync.py` 7 处 `read_text()` 加 `encoding="utf-8"`（Windows Python 默认 locale → GBK → 含非 GBK 字节的 TOML/JSON 直接炸）
- `test_paths.py::test_linux_xdg_default` 在 Windows 上 skip（用例 monkeypatch `os.name='posix'` 触发 PosixPath 实例化，Python 3.13+ 在 Windows 上禁止）

## 验证状态

- ✅ 全部测试在 Windows 上 `99 passed, 1 skipped`（之前 5 个失败）
- ✅ `.ps1` 跑通了 1/2/3/5 步：嵌入 Python 装好、torch 等依赖装到 pyembed、pnpm + vite build 完成
- ⚠️ **`.ps1` 没跑通最后的 `cargo build` 步**——本地 Cargo 1.76 < 1.78，hit "lockfile version 4 ... does not understand"。**这是本地工具链问题，不是脚本 bug**，`rustup update stable` 就解。脚本现在会 fail-fast 报 Cargo 版本要求。
- ⚠️ `_is_logged_in` 的 DOM 探测**没在真 BOSS 站上验证 selector 命中**——如果浮层 class 跟脚本里枚举的对不上仍会假阴性，下次 DRY_RUN 跑一遍如果还是 `feed_exhausted` 就抓真 DOM 修 selector。

## Test plan

- [ ] `rustup update stable` 后重跑 `scripts\build_standalone.ps1`，看 NSIS/MSI 生成
- [ ] 装一遍 installer，开 .exe，Process Explorer 看 `python313.dll` 加载路径是装目录里那份
- [ ] GUI 模式：开 Config 页应该立即出表单字段（不再"加载中…"）
- [ ] DRY_RUN 跑一遍：未登录场景应该看到 `URL 看起来已登录但页面上有登录浮层 → 判未登录` 日志，扫码后正常进 letter 生成