### PR TITLE
fix(ci): update smoke import check + bump version to 0.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           uv run python -c "from boss_zhipin.audit import validate_letter, log_attempt"
           uv run python -c "from boss_zhipin.audit.telemetry import record_llm_call, telemetry_summary, estimate_cost_cny"
           uv run python -c "from boss_zhipin.utils.retry import retry_with_backoff"
-          uv run python -c "from boss_zhipin.vectorization import VectorStore, embed_pdf, file_hash, split_text"
+          uv run python -c "from boss_zhipin.vectorization import VectorStore, embed_resume, text_hash, split_text"
           uv run python -c "from boss_zhipin.models.llm import PROVIDERS, generate_letter, _build_client"
           uv run python -c "from boss_zhipin.models.openai_assistant import create_assistant, OPENAI_API_KEY"
           uv run python -c "from boss_zhipin.models.prompts import assistant_instructions"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boss-zhipin-job-search"
-version = "0.3.1"
+version = "0.4.1"
 description = "Auto-apply for jobs on Boss ZhiPin with LLM-generated cover letters."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "boss-zhipin"
-version = "0.3.1"
+version = "0.4.1"
 description = "BOSS Zhipin Helper (PyTauri standalone)"
 authors = ["longsizhuo"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "BOSS Zhipin Helper",
-  "version": "0.3.1",
+  "version": "0.4.1",
   "identifier": "com.longsizhuo.boss-zhipin",
   "build": {
     "beforeDevCommand": "pnpm --dir ../tauri-ui dev",

--- a/src/boss_zhipin/tauri/Tauri.toml
+++ b/src/boss_zhipin/tauri/Tauri.toml
@@ -1,6 +1,6 @@
 "$schema" = "https://schema.tauri.app/config/2"
 productName = "BOSS Zhipin Helper"
-version = "0.3.1"
+version = "0.4.1"
 identifier = "com.longsizhuo.boss-zhipin"
 
 [build]

--- a/uv.lock
+++ b/uv.lock
@@ -119,7 +119,7 @@ wheels = [
 
 [[package]]
 name = "boss-zhipin-job-search"
-version = "0.3.1"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

- **Fix CI failure**: `ci.yml` smoke import check imported `embed_pdf` and `file_hash` from `boss_zhipin.vectorization`, but those names were renamed to `embed_resume` and `text_hash` in a prior commit. This caused the `test` job to fail on every push to master.
- **Bump version**: `pyproject.toml`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and `uv.lock` bumped from `0.3.1` → `0.4.1` to reflect new features/fixes since v0.4.0 (blacklist feature, GUI state-sync fix).

## Test plan

- [ ] CI `test` job passes (smoke import check no longer hits missing symbol)
- [ ] CI `no-leak` job passes
- [ ] After merge to master: push `v0.4.1` tag to trigger the Release workflow and build macOS + Windows installers

https://claude.ai/code/session_01KKtD6VRY3TYVwuQjMSQqjk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKtD6VRY3TYVwuQjMSQqjk)_