### PR TITLE
fix(gui): reset DRY_RUN env each run; document two-config sync

### DIFF
--- a/src/boss_zhipin/tauri/Tauri.toml
+++ b/src/boss_zhipin/tauri/Tauri.toml
@@ -1,3 +1,12 @@
+# 这是 **wheel dev 模式** 读的 Tauri 配置（standalone 模式读的是
+# src-tauri/tauri.conf.json，编译期被 generate_context! 烧进 Rust binary）。
+# 两份是**同一个 App 的两种运行模式各一份**，不是冗余，删任何一份对应模式起不来。
+#
+# ⚠️ 共享字段（productName / identifier / 窗口 title·label·width·height·
+# minWidth·minHeight / withGlobalTauri）必须跟 src-tauri/tauri.conf.json **逐字一致**，
+# 改一份记得同步改另一份。version 例外：release 时 scripts/set_version.py 会从 git
+# tag 把两份一起覆盖，平时不用手动对齐。（tauri.conf.json 是 JSON 不能写注释，
+# 所以这条提醒只放这里。）
 "$schema" = "https://schema.tauri.app/config/2"
 productName = "BOSS Zhipin Helper"
 version = "0.4.1"

--- a/src/boss_zhipin/tauri/__init__.py
+++ b/src/boss_zhipin/tauri/__init__.py
@@ -115,9 +115,15 @@ def _build_main_loop_factory(config: RunConfig):
         # 延迟 import，让没装 ``tauri`` 可选依赖时 import boss_zhipin.tauri 不立即炸。
         from boss_zhipin.cli import DEFAULT_RESUME_PATH, run_provider
 
-        # 同步到 env，业务代码深处读 env 的地方（DRY_RUN / RESUME_PATH 等）也能感知
+        # 同步到 env，业务代码深处读 env 的地方（DRY_RUN / RESUME_PATH 等）也能感知。
+        # DRY_RUN 必须**显式清掉**：os.environ 是进程级、跨 run 复用的。只设不清
+        # 的话，用户先勾 Dry-run 测一次留下 DRY_RUN=1，之后取消勾选真跑时，任何
+        # call-time 读 os.getenv("DRY_RUN") 的地方仍判为 dry-run → 招呼语只生成不
+        # 发送，且要重启 App 才好（非技术用户极难自查）。每次按当前勾选状态归位。
         if config.dry_run:
             environ["DRY_RUN"] = "1"
+        else:
+            environ.pop("DRY_RUN", None)
         environ["BOSS_USR_NAME"] = config.usr_name
         if config.resume_path:
             environ["RESUME_PATH"] = config.resume_path


### PR DESCRIPTION
## 背景

Review 打包易用性时发现的一个 GUI 真 bug + 一处配置漂移防护。

## DRY_RUN 只设不清（真 bug）

`src/boss_zhipin/tauri/__init__.py` 的 `_build_main_loop_factory` 在勾选 Dry-run 时设 `os.environ["DRY_RUN"]="1"`，但**取消勾选时不清**。`os.environ` 是进程级、跨 run 复用：

1. 用户勾 Dry-run 测一次 → 进程里留下 `DRY_RUN=1`
2. 取消勾选想真发 → 任何 call-time `os.getenv("DRY_RUN")` 仍判 dry-run
3. 招呼语只生成 + 写日志、**不发送**，且只能重启 App 才好

非技术用户几乎不可能自查。修复：`dry_run` 为假时 `environ.pop("DRY_RUN", None)`，让 env 跟随勾选框状态归位。

> 注：当前 GUI 发送判定走的是 `dry_run` 参数（`write_response` 读参数不读 env），所以今天还没炸；这是堵住「将来任何代码读 env DRY_RUN 就静默变 dry」的潜在脚枪。

## 两份 Tauri 配置的同步提醒

wheel 模式读 `src/boss_zhipin/tauri/Tauri.toml`、standalone 模式读 `src-tauri/tauri.conf.json`，是同一 App 两种运行模式各一份（非冗余）。共享字段（productName / identifier / 窗口尺寸 / withGlobalTauri）目前逐字一致，但只有 version 由 `set_version.py` 自动同步，其余手改易漂。在 Tauri.toml 顶部加注释钉死这条约束（tauri.conf.json 是 JSON 不能写注释，故只放 TOML 一侧）。

## 测试

`uv run pytest tests/ -k "tauri or env or version or paths"` → 28 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
