### PR TITLE
feat(gui): notify when a newer GitHub release exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           uv run python -c "from boss_zhipin.gui.env_io import read_env, write_env, field_meta, KNOWN_KEYS"
           uv run python -c "from boss_zhipin.gui.resume_io import store_resume, current_resume, DEFAULT_RESUME_PATH"
           uv run python -c "from boss_zhipin.gui.history import read_letters"
+          uv run python -c "from boss_zhipin.gui.updates import check_latest_release, is_newer, current_version, REPO"
 
       - name: 跑 pytest
         run: uv run pytest tests/ -v --tb=short

--- a/src/boss_zhipin/gui/updates.py
+++ b/src/boss_zhipin/gui/updates.py
@@ -1,0 +1,88 @@
+"""检查 GitHub 上有没有新版本——给 GUI 顶部「有新版」横幅用。
+
+**只提示，不自动下载安装**：standalone .app 体积 ~1.4 GB（嵌入式 Python +
+torch），Tauri updater 没有增量更新，每次发版整包重下不现实。所以这里只做
+"查最新 release tag → 比版本号 → 有新版给个下载链接"，下载/安装仍由用户手动
+一步，对大包反而更可控。
+
+设计：
+- 走 GitHub 公开 API ``/releases/latest``（自动排除 draft / prerelease，
+  用户只会被提示到正式版），未认证限速 60 次/小时/IP，每次启动只调一次够用。
+- **任何异常都静默降级**成"无更新"：没网 / 限速 / API 改版都不该让 App 报错
+  或卡住，顶多是这次没检查到。
+- 版本号用 ``packaging.version`` 做语义比较（已是项目依赖），别用字符串比
+  （"0.10.0" > "0.9.0" 字符串比会错）。
+"""
+from __future__ import annotations
+
+import json
+import logging
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+from urllib.request import Request, urlopen
+
+from packaging.version import InvalidVersion, Version
+
+log = logging.getLogger(__name__)
+
+# 发布仓库，跟 git remote 对齐。GitHub API 用同一个 owner/repo。
+REPO = "longsizhuo/BossZhiPin_Job_Search"
+_DIST_NAME = "boss-zhipin-job-search"
+_API_URL = f"https://api.github.com/repos/{REPO}/releases/latest"
+_RELEASES_PAGE = f"https://github.com/{REPO}/releases/latest"
+
+
+def current_version() -> str:
+    """当前安装的版本号（来自包元数据，set_version.py 维护的单一真相源）。
+
+    源码运行（没正经装包）时元数据可能缺失，返回 ``"0.0.0"`` 兜底——会让
+    任何线上 release 都判成"有新版"，但 dev 场景本就不靠这个提示。
+    """
+    try:
+        return _pkg_version(_DIST_NAME)
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+def is_newer(latest: str, current: str) -> bool:
+    """latest 是否严格新于 current。任一不是合法版本号 → False（不乱提示）。"""
+    try:
+        return Version(latest) > Version(current)
+    except InvalidVersion:
+        return False
+
+
+def _fetch_latest_tag(timeout: float) -> tuple[str, str]:
+    """打 GitHub API，返回 ``(tag_name, html_url)``。失败由调用方兜异常。
+
+    必须带 User-Agent，否则 GitHub API 直接 403。
+    """
+    req = Request(_API_URL, headers={
+        "User-Agent": "boss-zhipin-updater",
+        "Accept": "application/vnd.github+json",
+    })
+    with urlopen(req, timeout=timeout) as resp:  # noqa: S310 (固定 https GitHub API)
+        data = json.load(resp)
+    tag = str(data.get("tag_name", "")).lstrip("v")
+    url = str(data.get("html_url") or _RELEASES_PAGE)
+    return tag, url
+
+
+def check_latest_release(timeout: float = 5.0) -> dict[str, object]:
+    """查最新 release，返回前端横幅需要的全部字段。
+
+    返回 ``{current, latest, url, hasUpdate}``。**永不抛异常**：网络/解析/限速
+    出问题就当作"这次没查到新版"，``hasUpdate=False``、``latest=""``。
+    """
+    current = current_version()
+    try:
+        latest, url = _fetch_latest_tag(timeout)
+    except Exception as exc:  # noqa: BLE001 (有意吞掉所有错误，静默降级)
+        log.debug("检查更新失败（静默降级）：%s", exc)
+        return {"current": current, "latest": "", "url": _RELEASES_PAGE, "hasUpdate": False}
+
+    return {
+        "current": current,
+        "latest": latest,
+        "url": url,
+        "hasUpdate": is_newer(latest, current),
+    }

--- a/src/boss_zhipin/tauri/__init__.py
+++ b/src/boss_zhipin/tauri/__init__.py
@@ -311,6 +311,40 @@ async def get_telemetry_summary() -> dict[str, dict]:
     return {"summary": telemetry_summary(since_records=1000)}
 
 
+# ---------- 检查更新（只提示，不自动下载） ----------
+
+
+@commands.command()
+async def check_for_update() -> dict[str, object]:
+    """前端启动时调一次——查 GitHub 最新 release，返回是否有新版。
+
+    返回 ``{current, latest, url, hasUpdate}``。``check_latest_release`` 永不抛
+    异常（没网 / 限速静默降级成 hasUpdate=False），所以这里不用额外兜错。
+    """
+    from boss_zhipin.gui.updates import check_latest_release
+    return check_latest_release()
+
+
+class _OpenUrlBody(_CamelModel):
+    url: str
+
+
+@commands.command()
+async def open_release_page(body: _OpenUrlBody) -> dict[str, str]:
+    """用系统默认浏览器打开下载页——「前往下载」按钮调。
+
+    只允许打开本仓库 releases 域下的 URL，避免前端被注入任意 URL 当跳板。
+    """
+    import webbrowser
+
+    from boss_zhipin.gui.updates import REPO
+
+    allowed_prefix = f"https://github.com/{REPO}/releases"
+    target = body.url if body.url.startswith(allowed_prefix) else f"{allowed_prefix}/latest"
+    webbrowser.open(target)
+    return {"status": "opened"}
+
+
 def main() -> int:
     """启动 PyTauri app——根据 BOSS_TAURI_STANDALONE 自动切换 wheel / standalone。"""
     if BOSS_STANDALONE:

--- a/tauri-ui/src/App.tsx
+++ b/tauri-ui/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import RunPage from "./pages/Run";
 import ConfigPage from "./pages/Config";
 import HistoryPage from "./pages/History";
+import UpdateBanner from "./components/UpdateBanner";
 import { useRunStore } from "./store";
 
 type Tab = "run" | "config" | "history";
@@ -15,6 +16,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen flex flex-col">
+      <UpdateBanner />
       <header className="border-b-4 border-[var(--ink)] bg-[var(--paper)]">
         <div className="max-w-7xl mx-auto px-8 pt-8 pb-2 flex items-baseline gap-10">
           {/* 主标题：oversized serif italic，作为视觉锚点 */}

--- a/tauri-ui/src/components/UpdateBanner.tsx
+++ b/tauri-ui/src/components/UpdateBanner.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { ipc, type UpdateInfo } from "../lib/ipc";
+
+// 「有新版」横幅：挂载时静默查一次 GitHub 最新 release。
+// 只提示不自动安装——点「前往下载」用系统浏览器打开 release 页，下载/安装手动。
+// 没新版 / 没网 / 用户关掉本次提示时不渲染任何东西。
+export default function UpdateBanner() {
+  const [info, setInfo] = useState<UpdateInfo | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    // 后端 check_for_update 永不抛错；catch 只是兜 IPC 层意外，绝不打扰用户。
+    ipc.checkForUpdate()
+      .then((r) => {
+        if (alive && r.hasUpdate) setInfo(r);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (!info || dismissed) return null;
+
+  return (
+    <div className="bg-[var(--ink)] text-[var(--paper)] text-[11px] font-mono uppercase tracking-widest">
+      <div className="max-w-7xl mx-auto px-8 py-2 flex items-center gap-4">
+        <span>
+          新版本 v{info.latest} 可用 · 当前 v{info.current}
+        </span>
+        <button
+          onClick={() => ipc.openReleasePage(info.url).catch(() => {})}
+          className="underline underline-offset-2 hover:opacity-70 transition-opacity"
+        >
+          前往下载 ↗
+        </button>
+        <button
+          onClick={() => setDismissed(true)}
+          className="ml-auto hover:opacity-70 transition-opacity"
+          aria-label="关闭提示"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/tauri-ui/src/lib/ipc.ts
+++ b/tauri-ui/src/lib/ipc.ts
@@ -84,4 +84,18 @@ export const ipc = {
     pyInvoke<{ letters: LetterRecord[] }>("get_letters", { limit }),
   getTelemetrySummary: () =>
     pyInvoke<{ summary: TelemetrySummary }>("get_telemetry_summary", {}),
+  // 检查更新：查 GitHub 最新 release。后端永不抛错，没网时 hasUpdate=false。
+  checkForUpdate: () =>
+    pyInvoke<UpdateInfo>("check_for_update", {}),
+  // 用系统浏览器打开下载页（后端做了 URL 白名单校验）。
+  openReleasePage: (url: string) =>
+    pyInvoke<{ status: string }>("open_release_page", { url }),
+};
+
+// 检查更新返回：当前版本 / 最新版本 / 下载页 URL / 是否有新版。
+export type UpdateInfo = {
+  current: string;
+  latest: string;
+  url: string;
+  hasUpdate: boolean;
 };

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -1,0 +1,63 @@
+"""``gui.updates`` 单测——版本比较 + check_latest_release 的 happy / 降级路径。
+
+不打真网络：用 monkeypatch 替掉 ``_fetch_latest_tag``。
+"""
+from __future__ import annotations
+
+import pytest
+
+from boss_zhipin.gui import updates
+
+
+# ---------- is_newer ----------
+
+
+@pytest.mark.parametrize(
+    "latest, current, expected",
+    [
+        ("0.5.0", "0.4.1", True),     # happy：正常新版
+        ("0.10.0", "0.9.0", True),    # edge：字符串比会错判，语义比正确
+        ("0.4.1", "0.4.1", False),    # 相等不算新
+        ("0.4.0", "0.4.1", False),    # 旧版不提示
+        ("garbage", "0.4.1", False),  # edge：非法版本号 → 不乱提示
+    ],
+)
+def test_is_newer(latest, current, expected):
+    assert updates.is_newer(latest, current) is expected
+
+
+# ---------- check_latest_release ----------
+
+
+def test_check_latest_release_happy(monkeypatch):
+    monkeypatch.setattr(updates, "current_version", lambda: "0.4.1")
+    monkeypatch.setattr(
+        updates,
+        "_fetch_latest_tag",
+        lambda timeout: ("0.5.0", "https://github.com/longsizhuo/BossZhiPin_Job_Search/releases/tag/v0.5.0"),
+    )
+
+    result = updates.check_latest_release()
+
+    assert result["hasUpdate"] is True
+    assert result["current"] == "0.4.1"
+    assert result["latest"] == "0.5.0"
+    assert "releases/tag/v0.5.0" in str(result["url"])
+
+
+def test_check_latest_release_network_error_degrades(monkeypatch):
+    """没网 / API 出错时静默降级：不抛异常，hasUpdate=False。"""
+    monkeypatch.setattr(updates, "current_version", lambda: "0.4.1")
+
+    def boom(timeout):
+        raise OSError("network down")
+
+    monkeypatch.setattr(updates, "_fetch_latest_tag", boom)
+
+    result = updates.check_latest_release()
+
+    assert result["hasUpdate"] is False
+    assert result["latest"] == ""
+    assert result["current"] == "0.4.1"
+    # 降级也要给个可点的 releases 兜底链接
+    assert str(result["url"]).startswith("https://github.com/longsizhuo/BossZhiPin_Job_Search/releases")


### PR DESCRIPTION
## 背景

用户已成功安装 .app，问"自动检查更新怎么做？不会每次都得来 Release 吧？"

## 为什么不上全自动更新

standalone .app **~1.4 GB**（嵌入式 Python + torch），Tauri updater 没有增量更新——每次发版整包重下不现实，还要管签名私钥 / latest.json / CI，且 ad-hoc 签名未公证的自动安装包在 macOS 上仍可能触发 Gatekeeper。投入产出比不划算。

## 方案：轻量「检查更新 + 提示」

App 启动时静默查一次 GitHub 最新 release，有新版就在顶部显示一条横幅（含「前往下载」按钮 + 关闭按钮），点下载用系统浏览器打开 release 页。下载/安装仍手动一步，对大包反而更可控。

- `gui/updates.py`：打 GitHub `/releases/latest`（自动排除 draft/prerelease），用 `packaging.version` 比版本。**永不抛异常**——没网/限速/API 改版都静默降级成"无更新"。
- 两个 PyTauri command：`check_for_update` + `open_release_page`（URL 白名单只允许本仓库 releases 域，防注入）。
- 前端 `UpdateBanner`：只在有新版时渲染，挂载时查一次。

**零** Rust / 签名 / CI publish 改动，**零**新依赖（`webbrowser` 是 stdlib，`packaging` 已是依赖）。

## 测试

- `pytest tests/test_updates.py` → 7 passed（版本比较 happy/edge + 网络出错降级路径）
- 全量 `pytest tests/` → 128 passed
- 前端 `pnpm build`（tsc + vite）通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
