### PR TITLE
feat(gui): unify 3 API-key boxes into one provider picker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           # 是向后兼容 shim。CI 同时校验两侧：(1) 包导入，(2) main.py shim 能 import。
           uv run python -c "import main"
           uv run python -c "import boss_zhipin"
-          uv run python -c "from boss_zhipin.providers import PROVIDER_ENV_KEYS, PROVIDER_SIGNUP, detect_providers"
+          uv run python -c "from boss_zhipin.providers import PROVIDER_ENV_KEYS, PROVIDER_SIGNUP, PROVIDER_LABELS, detect_providers"
           uv run python -c "from boss_zhipin.cli import _cli_main, detect_providers, pick_provider, run_provider, RECOMMEND_URL, PROVIDER_ENV_KEYS"
           uv run python -c "from boss_zhipin.paths import is_standalone, app_data_dir, ensure_app_data_cwd, APP_IDENTIFIER"
           uv run python -c "from boss_zhipin.audit import validate_letter, log_attempt"
@@ -64,6 +64,7 @@ jobs:
           uv run python -c "from boss_zhipin.gui.resume_io import store_resume, current_resume, DEFAULT_RESUME_PATH"
           uv run python -c "from boss_zhipin.gui.history import read_letters"
           uv run python -c "from boss_zhipin.gui.updates import check_latest_release, is_newer, current_version, REPO"
+          uv run python -c "from boss_zhipin.gui.provider_config import read_provider_config, write_provider_config"
 
       - name: 跑 pytest
         run: uv run pytest tests/ -v --tb=short

--- a/src/boss_zhipin/gui/env_io.py
+++ b/src/boss_zhipin/gui/env_io.py
@@ -21,13 +21,17 @@ from pathlib import Path
 
 from dotenv import dotenv_values, set_key, unset_key
 
-# 暴露给前端的配置字段。每一项映射 ``.env`` 里一个 key。
+from boss_zhipin.providers import PROVIDER_ENV_KEYS
+
+# 暴露给前端 Config 通用表单的字段。每一项映射 ``.env`` 里一个 key。
 # 顺序决定前端表单顺序。
+#
+# 三个 API key（DEEPSEEK/OPENAI/ANTHROPIC_API_KEY）**故意不在这里**：它们改由
+# Config 页顶部的「AI 服务商」选择器统一管理（选一家 + 填一个 key），不再各占
+# 一个裸输入框——三个框会让小白以为"必须都填"。env key 本身不变，仍由
+# ``gui.provider_config`` 读写，并在下面的 ``_ALLOWED_KEYS`` 里放行。
 KNOWN_KEYS: list[tuple[str, str, bool]] = [
     # (env key, 字段说明, is_secret)
-    ("DEEPSEEK_API_KEY", "DeepSeek API key", True),
-    ("OPENAI_API_KEY", "OpenAI API key", True),
-    ("ANTHROPIC_API_KEY", "Anthropic (Claude) API key", True),
     ("BOSS_USR_NAME", "你的名字（招呼语署名）", False),
     ("BOSS_LABEL", "求职 tag（空走 BOSS 推荐 feed）", False),
     # RESUME_PATH 不在此处：改由「运行」tab 拖拽上传管理（gui.resume_io），
@@ -45,7 +49,14 @@ def _env_path() -> Path:
     return Path(".env")
 
 
-_ALLOWED_KEYS: frozenset[str] = frozenset(k for k, _, _ in KNOWN_KEYS)
+# 写白名单 = 通用表单字段 ∪ 三个 provider API key ∪ BOSS_PROVIDER（选服务商时存）。
+# API key / BOSS_PROVIDER 不在 KNOWN_KEYS（不渲染成通用框），但仍要能写，
+# 所以单独并进来。其余任何 key 一律拒写（防注入）。
+_ALLOWED_KEYS: frozenset[str] = (
+    frozenset(k for k, _, _ in KNOWN_KEYS)
+    | frozenset(PROVIDER_ENV_KEYS.values())
+    | {"BOSS_PROVIDER"}
+)
 
 
 def read_env() -> dict[str, str]:

--- a/src/boss_zhipin/gui/provider_config.py
+++ b/src/boss_zhipin/gui/provider_config.py
@@ -1,0 +1,78 @@
+"""GUI「AI 服务商」选择器的读/写——选一家 + 填一个 key，存进 ``.env``。
+
+替代以前 Config 页并排的三个 API key 输入框（小白会以为三个都要填）。现在：
+- 选服务商 → 存 ``BOSS_PROVIDER``
+- 只填**当前选中那家**的 key → 存对应的 ``*_API_KEY``
+
+**为什么读 ``.env`` 文件而不是 ``os.environ``**：GUI（PyTauri standalone）启动时
+入口不调 ``load_dotenv``，models 的 import-time load 要等首次 run 才触发，所以
+app 刚起来 ``os.environ`` 里没有 .env 的 key。Config 要展示"哪些已配/选了哪家"
+必须以**文件**为准（跟 ``env_io.read_env`` 一致）。run 路径不受影响：run_provider
+会 import models 触发 load_dotenv，key 那时已在 os.environ。
+"""
+from __future__ import annotations
+
+from dotenv import dotenv_values
+
+from boss_zhipin.gui.env_io import _env_path, write_env
+from boss_zhipin.providers import (
+    PROVIDER_ENV_KEYS,
+    PROVIDER_LABELS,
+    PROVIDER_SIGNUP,
+)
+
+
+def _file_values() -> dict[str, str | None]:
+    path = _env_path()
+    return dotenv_values(path) if path.is_file() else {}
+
+
+def read_provider_config() -> dict[str, object]:
+    """返回前端服务商选择器需要的全部信息。
+
+    ``{active, providers: [{name, label, signupUrl, hasKey}]}``。``active`` 是
+    用户选过的 ``BOSS_PROVIDER``；没选过 / 非法时回退到第一个已配 key 的服务商，
+    都没配就 ``deepseek``（让用户有个默认落点）。
+    """
+    raw = _file_values()
+    configured = {
+        name for name, env in PROVIDER_ENV_KEYS.items()
+        if (raw.get(env) or "").strip()
+    }
+
+    active = (raw.get("BOSS_PROVIDER") or "").strip()
+    if active not in PROVIDER_ENV_KEYS:
+        active = next((n for n in PROVIDER_ENV_KEYS if n in configured), "deepseek")
+
+    return {
+        "active": active,
+        "providers": [
+            {
+                "name": name,
+                "label": PROVIDER_LABELS[name],
+                "signupUrl": PROVIDER_SIGNUP[name],
+                "hasKey": name in configured,
+            }
+            for name in PROVIDER_ENV_KEYS
+        ],
+    }
+
+
+def write_provider_config(active: str, api_key: str | None) -> None:
+    """存选定的服务商（+ 可选地存它的 key）。
+
+    - ``active`` 非法 → ``ValueError``（前端 catch 可见）。
+    - ``api_key`` 为 ``None`` / 空串 → **只切服务商、不动已存的 key**。这样用户
+      切来切去看不同家时，不会把之前填好的 key 误清空（区别于 env_io 的
+      "空=删除"语义，这里刻意不删）。
+    - ``api_key`` 非空 → 连同写进对应 ``*_API_KEY``。
+    写操作复用 ``env_io.write_env``：落盘 + 同步 ``os.environ``（存完即时生效，
+    切回运行页不用重启）。
+    """
+    if active not in PROVIDER_ENV_KEYS:
+        raise ValueError(f"unknown provider: {active!r}")
+
+    updates: dict[str, str] = {"BOSS_PROVIDER": active}
+    if api_key:
+        updates[PROVIDER_ENV_KEYS[active]] = api_key
+    write_env(updates)

--- a/src/boss_zhipin/providers.py
+++ b/src/boss_zhipin/providers.py
@@ -30,6 +30,14 @@ PROVIDER_SIGNUP: dict[str, str] = {
     "claude": "https://console.anthropic.com/settings/keys",
 }
 
+# provider 名 → 给用户看的显示名（GUI 服务商选择器用）。内部名 chatgpt/claude
+# 是历史 CLI 参数，对用户没意义，展示层统一成大家认识的品牌名。
+PROVIDER_LABELS: dict[str, str] = {
+    "deepseek": "DeepSeek",
+    "chatgpt": "OpenAI",
+    "claude": "Anthropic · Claude",
+}
+
 
 def detect_providers() -> list[str]:
     """返回当前 env 里配了 API key 的 provider 名字列表。"""

--- a/src/boss_zhipin/tauri/__init__.py
+++ b/src/boss_zhipin/tauri/__init__.py
@@ -227,7 +227,34 @@ async def shutdown_browser() -> dict[str, str]:
     return {"status": "ok"}
 
 
-# ---------- Config 面板 ----------
+# ---------- Config 面板：AI 服务商选择器 ----------
+
+
+@commands.command()
+async def get_provider_config() -> dict[str, object]:
+    """返回服务商选择器需要的信息：``{active, providers: [...]}``。
+
+    读 .env 文件（不是 os.environ）——GUI 启动时 env 还没 load，见
+    ``gui.provider_config`` 的说明。
+    """
+    from boss_zhipin.gui.provider_config import read_provider_config
+    return read_provider_config()
+
+
+class _ProviderConfigBody(_CamelModel):
+    active: str
+    api_key: str = ""  # 空 → 只切服务商，不动已存的 key
+
+
+@commands.command()
+async def set_provider_config(body: _ProviderConfigBody) -> dict[str, str]:
+    """存选定的服务商（+ 可选 key）。unknown provider → ValueError 被前端 catch。"""
+    from boss_zhipin.gui.provider_config import write_provider_config
+    write_provider_config(body.active, body.api_key or None)
+    return {"status": "saved"}
+
+
+# ---------- Config 面板：通用字段 ----------
 
 
 @commands.command()

--- a/tauri-ui/src/lib/ipc.ts
+++ b/tauri-ui/src/lib/ipc.ts
@@ -76,6 +76,11 @@ export const ipc = {
   getEnvFields: () => pyInvoke<{ fields: EnvField[] }>("get_env_fields", {}),
   writeEnvFields: (updates: Record<string, string>) =>
     pyInvoke<{ status: string }>("write_env_fields", { updates }),
+  // AI 服务商：选一家 + 填一个 key。apiKey 留空 = 只切服务商、不动已存的 key。
+  getProviderConfig: () =>
+    pyInvoke<ProviderConfig>("get_provider_config", {}),
+  setProviderConfig: (active: string, apiKey: string) =>
+    pyInvoke<{ status: string }>("set_provider_config", { active, apiKey }),
   // 简历：set_resume 把拖入的 PDF 复制进 app 数据目录的 resume/；get_resume 读回当前简历。
   setResume: (path: string) =>
     pyInvoke<{ filename: string; path: string }>("set_resume", { path }),
@@ -98,4 +103,17 @@ export type UpdateInfo = {
   latest: string;
   url: string;
   hasUpdate: boolean;
+};
+
+// AI 服务商元数据：内部名 / 显示名 / 申请 key 的页面 / 是否已配 key。
+export type ProviderMeta = {
+  name: string;       // deepseek / chatgpt / claude（内部名，传给 start_run）
+  label: string;      // DeepSeek / OpenAI / Anthropic · Claude（给用户看）
+  signupUrl: string;
+  hasKey: boolean;
+};
+
+export type ProviderConfig = {
+  active: string;             // 当前选定的服务商内部名
+  providers: ProviderMeta[];
 };

--- a/tauri-ui/src/pages/Config.tsx
+++ b/tauri-ui/src/pages/Config.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from "react";
-import { ipc, type EnvField } from "../lib/ipc";
+import { ipc, type EnvField, type ProviderConfig } from "../lib/ipc";
 
 // 配置页：.env 编辑
 // monochrome 设计：editorial 表单 —— 每个字段 key 用反色 mono 标签
 // 错误信息用黑边粗框 + 黑底白字标签替代红色
+//
+// 顶部「AI 服务商」段：选一家 + 填一个 key（取代以前并排的三个 API key 框，
+// 小白会以为三个都得填）。下面是其余通用字段（名字 / tag / 模型选项…）。
 export default function ConfigPage() {
   const [fields, setFields] = useState<EnvField[]>([]);
   const [edits, setEdits] = useState<Record<string, string>>({});
@@ -11,6 +14,12 @@ export default function ConfigPage() {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // 服务商段状态
+  const [providerCfg, setProviderCfg] = useState<ProviderConfig | null>(null);
+  const [selectedProvider, setSelectedProvider] = useState<string>("");
+  // null = 用户没动 key 框（保存时不传 key，不覆盖已存的）；字符串 = 用户输入了新 key
+  const [keyEdit, setKeyEdit] = useState<string | null>(null);
 
   useEffect(() => {
     refresh();
@@ -20,9 +29,15 @@ export default function ConfigPage() {
     setLoading(true);
     setError(null);
     try {
-      const { fields } = await ipc.getEnvFields();
+      const [{ fields }, pc] = await Promise.all([
+        ipc.getEnvFields(),
+        ipc.getProviderConfig(),
+      ]);
       setFields(fields);
       setEdits({});
+      setProviderCfg(pc);
+      setSelectedProvider(pc.active);
+      setKeyEdit(null);
     } catch (e) {
       setError(String(e));
     } finally {
@@ -39,11 +54,32 @@ export default function ConfigPage() {
     return key in edits ? edits[key] : fallback;
   }
 
+  function pickProvider(name: string) {
+    setSaved(false);
+    setSelectedProvider(name);
+  }
+
+  function editKey(value: string) {
+    setSaved(false);
+    setKeyEdit(value);
+  }
+
+  const providerDirty =
+    providerCfg !== null &&
+    (selectedProvider !== providerCfg.active || keyEdit !== null);
+  const dirty = Object.keys(edits).length > 0 || providerDirty;
+
   async function save() {
     setSaving(true);
     setError(null);
     try {
-      await ipc.writeEnvFields(edits);
+      // 先存服务商（apiKey 留空 = 只切，不动已存 key），再存通用字段
+      if (providerDirty) {
+        await ipc.setProviderConfig(selectedProvider, keyEdit ?? "");
+      }
+      if (Object.keys(edits).length > 0) {
+        await ipc.writeEnvFields(edits);
+      }
       setSaved(true);
       await refresh();
     } catch (e) {
@@ -53,7 +89,7 @@ export default function ConfigPage() {
     }
   }
 
-  const dirty = Object.keys(edits).length > 0;
+  const selectedMeta = providerCfg?.providers.find((p) => p.name === selectedProvider);
 
   return (
     <div className="space-y-10">
@@ -94,14 +130,80 @@ export default function ConfigPage() {
         </div>
       )}
 
-      {/* === 表单 === */}
-      <section>
-        {loading ? (
-          <div className="font-mono text-sm text-[var(--muted-fg)] italic">
-            Loading...
-          </div>
-        ) : (
-          <div className="divide-y divide-[var(--border-light)]">
+      {loading ? (
+        <div className="font-mono text-sm text-[var(--muted-fg)] italic">
+          Loading...
+        </div>
+      ) : (
+        <>
+          {/* === AI 服务商：选一家 + 填一个 key === */}
+          {providerCfg && (
+            <section className="space-y-4">
+              <div>
+                <label className="field-label">AI 服务商 / Provider</label>
+                <p className="mt-1 text-xs font-mono text-[var(--muted-fg)] italic">
+                  三家任选其一即可跑——选谁就填谁的 key
+                </p>
+              </div>
+
+              {/* 分段选择器：每家一个按钮，已配过 key 的右上角打 ✓ */}
+              <div className="flex flex-wrap gap-3">
+                {providerCfg.providers.map((p) => {
+                  const active = p.name === selectedProvider;
+                  return (
+                    <button
+                      key={p.name}
+                      onClick={() => pickProvider(p.name)}
+                      className={[
+                        "px-4 py-2 border-2 font-mono text-sm transition-colors duration-100",
+                        active
+                          ? "bg-[var(--ink)] text-[var(--paper)] border-[var(--ink)]"
+                          : "bg-[var(--paper)] text-[var(--ink)] border-[var(--border-light)] hover:border-[var(--ink)]",
+                      ].join(" ")}
+                    >
+                      {p.label}
+                      {p.hasKey && <span className="ml-2">✓</span>}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {/* 当前选中那家的单个 key 框 */}
+              <div className="grid grid-cols-1 md:grid-cols-[200px_1fr] gap-4 md:gap-10 items-start pt-2">
+                <div>
+                  <div className="font-mono text-xs uppercase tracking-widest bg-[var(--ink)] text-[var(--paper)] inline-block px-2 py-1">
+                    {selectedMeta ? `${selectedMeta.label} API Key` : "API Key"}
+                  </div>
+                  <p className="mt-2 text-[10px] font-mono uppercase tracking-widest text-[var(--muted-fg)] italic">
+                    secret · 密文
+                  </p>
+                  {selectedMeta && (
+                    <p className="mt-2 text-xs font-serif leading-snug text-[var(--muted-fg)] break-all">
+                      没有 key？去这里申请：
+                      <br />
+                      {selectedMeta.signupUrl}
+                    </p>
+                  )}
+                </div>
+                <div>
+                  <input
+                    type="password"
+                    value={keyEdit ?? ""}
+                    onChange={(e) => editKey(e.target.value)}
+                    className="field-input font-mono"
+                    placeholder={
+                      selectedMeta?.hasKey
+                        ? "已配置 · 留空保持不变，输入则覆盖"
+                        : "粘贴 API Key"
+                    }
+                  />
+                </div>
+              </div>
+            </section>
+          )}
+
+          {/* === 其余通用字段 === */}
+          <section className="divide-y divide-[var(--border-light)] border-t-2 border-[var(--ink)] pt-2">
             {fields.map((f) => (
               <div key={f.key} className="py-6 grid grid-cols-1 md:grid-cols-[200px_1fr] gap-4 md:gap-10 items-start">
                 {/* 左：key + 描述 */}
@@ -132,15 +234,14 @@ export default function ConfigPage() {
                 </div>
               </div>
             ))}
-          </div>
-        )}
-      </section>
+          </section>
+        </>
+      )}
 
       {/* === 说明 === */}
       <section className="border-t-4 border-[var(--ink)] pt-6">
         <p className="text-sm font-serif italic text-[var(--muted-fg)] leading-relaxed max-w-2xl">
-          保存后即时生效——切回「运行」tab 就能在 provider 下拉里看到新配的 key，
-          无需重启 App。
+          保存后即时生效——切回「运行」tab 就能用上新选的服务商，无需重启 App。
         </p>
       </section>
     </div>

--- a/tauri-ui/src/pages/Run.tsx
+++ b/tauri-ui/src/pages/Run.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Channel } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
-import { ipc, type ProgressEvent, type RunConfig, type ResumeInfo } from "../lib/ipc";
+import { ipc, type ProgressEvent, type RunConfig, type ResumeInfo, type ProviderMeta } from "../lib/ipc";
 import { useRunStore } from "../store";
 
 // 运行页：editorial 三段式布局
@@ -10,7 +10,8 @@ import { useRunStore } from "../store";
 // 3) 控制按钮行（黑底白字反色）
 // 4) 双面板：进度事件 + 日志（日志保留黑底白字，刚好契合 monochrome）
 export default function RunPage() {
-  const [providers, setProviders] = useState<string[]>([]);
+  // 当前选定的服务商（在「配置」tab 选）——运行页只读展示，不再有下拉。
+  const [activeProvider, setActiveProvider] = useState<ProviderMeta | null>(null);
   const [providersError, setProvidersError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -40,12 +41,12 @@ export default function RunPage() {
   const eventsScrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    ipc.detectProviders()
-      .then(({ providers }) => {
-        setProviders(providers);
-        if (providers.length > 0 && !useRunStore.getState().formProvider) {
-          setFormState({ formProvider: providers[0] });
-        }
+    // 服务商在「配置」tab 选；这里只取 active 那家用于运行 + 只读展示。
+    ipc.getProviderConfig()
+      .then((cfg) => {
+        const active = cfg.providers.find((p) => p.name === cfg.active) ?? null;
+        setActiveProvider(active);
+        setFormState({ formProvider: cfg.active });
       })
       .catch((e) => setProvidersError(String(e)));
 
@@ -131,8 +132,8 @@ export default function RunPage() {
       alert("请填用户名");
       return;
     }
-    if (!provider) {
-      alert("没有可用的 provider，先去配置 tab 填 API key");
+    if (!activeProvider || !activeProvider.hasKey) {
+      alert("当前服务商还没配 API key —— 去「配置」tab 选服务商并填 key");
       return;
     }
     setBusy(true);
@@ -239,30 +240,23 @@ export default function RunPage() {
             />
           </Field>
 
-          <Field label="LLM Provider">
+          <Field label="AI 服务商" hint="在「配置」tab 选">
             {providersError ? (
               <div className="text-sm font-mono py-2 border-b-2 border-[var(--ink)]">
                 <span className="badge-outline mr-2">ERROR</span>
-                检测失败：{providersError}
+                读取失败：{providersError}
               </div>
-            ) : providers.length === 0 ? (
+            ) : !activeProvider || !activeProvider.hasKey ? (
               <div className="text-sm font-mono py-2 border-b-2 border-[var(--ink)]">
                 <span className="badge-invert mr-2">No Key</span>
-                去「配置」tab 填一个 API key
+                去「配置」tab 选服务商并填 API key
               </div>
             ) : (
-              <select
-                value={provider}
-                onChange={(e) => setFormState({ formProvider: e.target.value })}
-                disabled={running}
-                className="field-input"
-              >
-                {providers.map((p) => (
-                  <option key={p} value={p}>
-                    {p}
-                  </option>
-                ))}
-              </select>
+              // 只读展示：服务商在配置页选，这里不再有下拉
+              <div className="text-sm font-mono py-2 border-b-2 border-[var(--ink)] flex items-center gap-2">
+                <span className="badge-invert">{activeProvider.label}</span>
+                <span className="text-[var(--muted-fg)] text-xs">已配置 · 改用别家去「配置」tab</span>
+              </div>
             )}
           </Field>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,8 @@ _PROJECT_ENV_VARS = (
     "DEEPSEEK_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
     # 用户输入兜底
     "BOSS_USR_NAME", "BOSS_LABEL", "RESUME_PATH",
+    # GUI 选定的 provider
+    "BOSS_PROVIDER",
     # OpenAI / 模型选项
     "OPENAI_BASE_URL", "CHATGPT_MODEL",
     # retry 装饰器在 import time 读这些，本机有 export 会影响装饰器默认值

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -1,0 +1,81 @@
+"""gui.provider_config 的读/写——服务商选择器的 .env 真相源行为。
+
+重点：
+- 读以 **.env 文件** 为准（GUI 启动时 os.environ 还没 load）。
+- 切服务商不传 key **不能清掉** 已存的 key（区别于 env_io 的"空=删除"）。
+"""
+from __future__ import annotations
+
+import pytest
+
+from boss_zhipin.gui import provider_config as pc
+
+
+@pytest.fixture
+def in_tmp_cwd(tmp_path, monkeypatch):
+    """切到临时 cwd——provider_config / env_io 都用相对路径 ``.env``。
+
+    同时清掉会被 write_env 写进 os.environ 的几个 key，让 monkeypatch 在
+    teardown 时还原，不污染其他用例。
+    """
+    monkeypatch.chdir(tmp_path)
+    for env in ("BOSS_PROVIDER", "DEEPSEEK_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(env, raising=False)
+    return tmp_path
+
+
+def test_read_empty_defaults_to_deepseek(in_tmp_cwd):
+    cfg = pc.read_provider_config()
+    assert cfg["active"] == "deepseek"
+    # 三家都列出，但都没配 key
+    names = [p["name"] for p in cfg["providers"]]
+    assert names == ["deepseek", "chatgpt", "claude"]
+    assert all(p["hasKey"] is False for p in cfg["providers"])
+    # 显示名给的是品牌名，不是内部代号
+    labels = {p["name"]: p["label"] for p in cfg["providers"]}
+    assert labels["chatgpt"] == "OpenAI"
+
+
+def test_write_then_read_roundtrip(in_tmp_cwd):
+    pc.write_provider_config("claude", "sk-ant-xxx")
+
+    # 落盘了 BOSS_PROVIDER + 对应 key
+    env_text = (in_tmp_cwd / ".env").read_text()
+    assert "BOSS_PROVIDER=claude" in env_text
+    assert "ANTHROPIC_API_KEY=sk-ant-xxx" in env_text
+
+    cfg = pc.read_provider_config()
+    assert cfg["active"] == "claude"
+    claude = next(p for p in cfg["providers"] if p["name"] == "claude")
+    assert claude["hasKey"] is True
+
+
+def test_active_falls_back_to_first_configured(in_tmp_cwd):
+    """没存过 BOSS_PROVIDER 时，active 落到第一个已配 key 的服务商。"""
+    # 只配 OpenAI 的 key，不写 BOSS_PROVIDER
+    from boss_zhipin.gui.env_io import write_env
+    write_env({"OPENAI_API_KEY": "sk-openai"})
+
+    cfg = pc.read_provider_config()
+    assert cfg["active"] == "chatgpt"
+
+
+def test_switch_provider_without_key_keeps_existing_key(in_tmp_cwd):
+    """切服务商不传 key，不能误删之前填好的 key。"""
+    pc.write_provider_config("claude", "sk-ant-keep")
+    # 切到 deepseek，但 deepseek 还没 key，且不传 api_key
+    pc.write_provider_config("deepseek", None)
+
+    env_text = (in_tmp_cwd / ".env").read_text()
+    assert "ANTHROPIC_API_KEY=sk-ant-keep" in env_text  # 旧 key 仍在
+    assert "BOSS_PROVIDER=deepseek" in env_text
+
+    cfg = pc.read_provider_config()
+    assert cfg["active"] == "deepseek"
+    claude = next(p for p in cfg["providers"] if p["name"] == "claude")
+    assert claude["hasKey"] is True  # claude 的 key 没被清
+
+
+def test_unknown_provider_raises(in_tmp_cwd):
+    with pytest.raises(ValueError):
+        pc.write_provider_config("gemini", "sk-x")


### PR DESCRIPTION
## 背景

用户反馈：进 Config 看到 **DeepSeek / OpenAI / Anthropic 三个并排的 API key 框**，小白会以为三个都得填——实际上三家任选其一即可，DeepSeek 只是其中之一，不该被凸显。

## 改动

Config 顶部改成「**先选 AI 服务商 → 只填一个 key**」，三家平等：

- **providers.py**：加 `PROVIDER_LABELS`（给用户看的品牌名，内部名 chatgpt/claude 不外露）。
- **env_io.py**：把 3 个 API key 从 `KNOWN_KEYS`（通用渲染列表）移除，不再各占一个裸框；但通过扩展 `_ALLOWED_KEYS` 白名单保留它们 + `BOSS_PROVIDER` 的可写性。
- **gui/provider_config.py**（新）：读/写「选定服务商 + 它的 key」，以 **.env 文件**为真相源（GUI 启动时还没 load_dotenv，os.environ 是空的）。**切服务商不输入 key 不会清掉已存的 key**（区别于 env_io 的"空=删除"）。
- 两个 PyTauri command：`get_provider_config` / `set_provider_config`。
- **Config.tsx**：服务商分段选择器（已配的打 ✓）+ 单个 key 框。
- **Run.tsx**：provider 下拉改成**只读展示**当前选定的服务商；开始前校验该服务商已配 key。

选定的服务商持久化为 `.env` 里的 `BOSS_PROVIDER`。

## 选型说明

按和你对齐的「合并成单一 provider」方案：Run 页不再有 provider 下拉，跟着 Config 走。多 key 仍可存（切服务商即切 key），但同一时刻只用选定那家。

## 测试

- `tests/test_provider_config.py`：读默认值 / 写回往返 / 切换不清 key / 未知 provider 报错（5 例）
- 全量 `pytest tests/` → **133 passed**
- 前端 `pnpm build`（tsc + vite）通过

## ⚠️ stacked PR

本 PR base 是 `feat/update-check`（#25），因为两者都改了 `tauri-ui/src/lib/ipc.ts`。**先合 #25**，GitHub 会自动把本 PR retarget 到 master；或先合本 PR 链。单看 diff 只含本功能改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
